### PR TITLE
Change fog requirement to be looser

### DIFF
--- a/vagrant-google.gemspec
+++ b/vagrant-google.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-google"
 
-  s.add_runtime_dependency "fog", "~> 1.15.0"
+  s.add_runtime_dependency "fog", "~> 1.19"
   s.add_runtime_dependency "google-api-client"
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
Also up the base to 1.19, which has support for the most recent API version.
