### PR TITLE
bump fog version in gemspec

### DIFF
--- a/vagrant-google.gemspec
+++ b/vagrant-google.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-google"
 
-  s.add_runtime_dependency "fog", "~> 1.19"
+  s.add_runtime_dependency "fog", "~> 1.22"
   s.add_runtime_dependency "google-api-client"
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
Bumping fog version in an effort to keep vagrant-aws, vagrant-google, and vagrant-rackspace in sync.
