### PR TITLE
Support user specified rsync excludes

### DIFF
--- a/lib/vagrant-google/action/sync_folders.rb
+++ b/lib/vagrant-google/action/sync_folders.rb
@@ -61,10 +61,13 @@ module VagrantPlugins
               Array(ssh_info[:private_key_path]).map { |path| "-i '#{path}' " }.join
             end
 
+            #collect rsync excludes specified :rsync__excludes=>['path1',...] in synced_folder options
+            excludes = ['.vagrant/', *Array(data[:rsync__excludes])]
+
             # Rsync over to the guest path using the SSH info
             command = [
               "rsync", "--verbose", "--archive", "-z",
-              "--exclude", ".vagrant/",
+              *excludes.map{|e|['--exclude', e]}.flatten,
               "-e", "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no #{ssh_key_options(ssh_info)}",
               hostpath,
               "#{ssh_info[:username]}@#{ssh_info[:host]}:#{guestpath}"]


### PR DESCRIPTION
This change respects the user configured `rsync__excludes` parameter for the synced folders as the normal `vagrant rsync` command does.

Similar change as mitchellh/vagrant-aws#156
