### PR TITLE
Be more specific about Fog dependency

### DIFF
--- a/vagrant-google.gemspec
+++ b/vagrant-google.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-google"
 
-  s.add_runtime_dependency "fog", "~> 1.22"
+  s.add_runtime_dependency "fog", "1.22"
   s.add_runtime_dependency "google-api-client"
   #s.add_runtime_dependency "pry"
   #s.add_runtime_dependency "pry-nav"


### PR DESCRIPTION
Because the maintainers are adding breaking api changes into minor-version
updates, we should be more specific about what version to use.

fixes #25