### PR TITLE
Fix rsync on windows (duplicate of vagrant-aws bug) 

### DIFF
--- a/lib/vagrant-google/action/sync_folders.rb
+++ b/lib/vagrant-google/action/sync_folders.rb
@@ -14,6 +14,7 @@
 require "log4r"
 require "vagrant/util/subprocess"
 require "vagrant/util/scoped_hash_override"
+require "vagrant/util/which"
 
 module VagrantPlugins
   module Google
@@ -38,6 +39,11 @@ module VagrantPlugins
 
             # Ignore disabled shared folders
             next if data[:disabled]
+            
+            unless Vagrant::Util::Which.which('rsync')
+              env[:ui].warn(I18n.t('vagrant_aws.rsync_not_found_warning'))
+              break
+            end
 
             hostpath  = File.expand_path(data[:hostpath], env[:root_path])
             guestpath = data[:guestpath]

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -15,6 +15,9 @@ en:
       Machine is booted and ready for use!
     ready_ssh: |-
       Machine is ready for SSH access!
+    rsync_not_found_warning: |-
+      Warning! Folder sync disabled because the rsync binary is missing.
+      Make sure rsync is installed and the binary can be found in the PATH.
     rsync_folder: |-
       Rsyncing folder: %{hostpath} => %{guestpath}
     terminating: |-


### PR DESCRIPTION
Fixes issue with rsync path on Windows. 

Duplicated [solution](https://github.com/mitchellh/vagrant-aws/pull/77/commits) from PR in aws plugin

