### PR TITLE
Adding disk type support.

### DIFF
--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -51,6 +51,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :disk_name
 
+      # The type of the disk to be used, such as "pd-standard"
+      #
+      # @return [String]
+      attr_accessor :disk_type
+
       # The user metadata string
       #
       # @return [Hash<String, String>]
@@ -111,6 +116,7 @@ module VagrantPlugins
         @machine_type        = UNSET_VALUE
         @disk_size           = UNSET_VALUE
         @disk_name           = UNSET_VALUE
+        @disk_type           = UNSET_VALUE
         @metadata            = {}
         @name                = UNSET_VALUE
         @network             = UNSET_VALUE
@@ -207,6 +213,9 @@ module VagrantPlugins
 
         # Default disk name is nil
         @disk_name = nil if @disk_name == UNSET_VALUE
+
+        # Default disk type is pd-standard
+        @disk_type = "pd-standard" if @disk_type == UNSET_VALUE
 
         # Instance name defaults to a new datetime value (hour granularity)
         t = Time.now

--- a/spec/vagrant-google/config_spec.rb
+++ b/spec/vagrant-google/config_spec.rb
@@ -36,6 +36,7 @@ describe VagrantPlugins::Google::Config do
     its("machine_type")      { should == "n1-standard-1" }
     its("disk_size")         { should == 10 }
     its("disk_name")         { should be_nil }
+    its("disk_type")         { should == "pd-standard" }
     its("instance_ready_timeout") { should == 20 }
     its("metadata")          { should == {} }
     its("tags")              { should == [] }
@@ -46,7 +47,7 @@ describe VagrantPlugins::Google::Config do
     # simple boilerplate test, so I cut corners here. It just sets
     # each of these attributes to "foo" in isolation, and reads the value
     # and asserts the proper result comes back out.
-    [:name, :image, :zone, :instance_ready_timeout, :machine_type, :disk_size, :disk_name,
+    [:name, :image, :zone, :instance_ready_timeout, :machine_type, :disk_size, :disk_name, :disk_type,
       :network, :metadata, :can_ip_forward, :external_ip, :autodelete_disk].each do |attribute|
 
       it "should not default #{attribute} if overridden" do
@@ -91,6 +92,7 @@ describe VagrantPlugins::Google::Config do
     let(:config_machine_type)    { "foo" }
     let(:config_disk_size)       { 99 }
     let(:config_disk_name)       { "foo" }
+    let(:config_disk_type)       { "foo" }
     let(:config_name)            { "foo" }
     let(:config_zone)            { "foo" }
     let(:config_network)         { "foo" }
@@ -104,6 +106,7 @@ describe VagrantPlugins::Google::Config do
       instance.machine_type      = config_machine_type
       instance.disk_size         = config_disk_size
       instance.disk_name         = config_disk_name
+      instance.disk_type         = config_disk_type
       instance.zone              = config_zone
       instance.can_ip_forward    = can_ip_forward
       instance.external_ip       = external_ip
@@ -131,6 +134,7 @@ describe VagrantPlugins::Google::Config do
       its("machine_type")      { should == config_machine_type }
       its("disk_size")         { should == config_disk_size }
       its("disk_name")         { should == config_disk_name }
+      its("disk_type")         { should == config_disk_type }
       its("network")           { should == config_network }
       its("zone")              { should == config_zone }
       its("can_ip_forward")    { should == can_ip_forward }
@@ -158,6 +162,7 @@ describe VagrantPlugins::Google::Config do
       its("machine_type")      { should == config_machine_type }
       its("disk_size")         { should == config_disk_size }
       its("disk_name")         { should == config_disk_name }
+      its("disk_type")         { should == config_disk_type }
       its("network")           { should == config_network }
       its("zone")              { should == zone_name }
       its("can_ip_forward")    { should == can_ip_forward }


### PR DESCRIPTION
Adding disk type support for GCE. Users should now be able to choose other disk types, like "pd-ssd". Error messages will be displayed if the disk type is not available in the region selected.