### PR TITLE
Bumping Vagrant gem to 1.7.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git", :tag => "v1.7.2"
+  gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git"
 end
 
 group :plugins do

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
 # Copyright 2013 Google Inc. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,5 +20,9 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git", :tag => "v1.2.7"
+  gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git", :tag => "v1.7.2"
+end
+
+group :plugins do
+  gem "vagrant-google" , path: "."
 end

--- a/vagrant-google.gemspec
+++ b/vagrant-google.gemspec
@@ -1,11 +1,11 @@
 # Copyright 2013 Google Inc. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-google"
 
-  s.add_runtime_dependency "fog", "1.22"
+  s.add_runtime_dependency "fog", "1.29"
   s.add_runtime_dependency "google-api-client"
   #s.add_runtime_dependency "pry"
   #s.add_runtime_dependency "pry-nav"


### PR DESCRIPTION
Bumping up Vagrant gem version to 1.7.2 and updating the plugin load mechanism accordingly.
Fog needs to be bumped up as well, due to dependency issues (made sure #25 doesn't pop up again).

One note before you consider the pull request - maybe it makes sense to just refer to the master in dev environment, as in:
gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git"
, instead of
gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git", :tag => "v1.7.2"
(aws, berkshelf have updated to do the same after 1.5 it seems)

However, I'm not sure whether there was a particular reason for sticking to a certain version, so putting this into consideration here first.