### PR TITLE
Proper error handling for disk_type and external_ip settings

### DIFF
--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -65,13 +65,12 @@ module VagrantPlugins
           env[:ui].info(" -- Autodelete Disk: #{autodelete_disk}")
           begin
             request_start_time = Time.now().to_i
-            # TODO: check if external IP is available
             if !external_ip.nil?
               address = env[:google_compute].addresses.get_by_ip_address(external_ip)
               if !address.nil?
                 if address.in_use?
-                  env[:ui].error("Specified external_ip is already in use, cannot be used!")
-                  raise Errors::VagrantGoogleError, "Specified external_ip is already in use, cannot be used!"
+                  raise Errors::ExternalIpError,
+                    :externalip => external_ip
                 end
               end
             end
@@ -81,8 +80,8 @@ module VagrantPlugins
               if !disk_type_obj.empty?
                 disk_type = disk_type_obj[0]["selfLink"]
               else
-                env[:ui].error("Specified disk type: #{disk_type} is not available in the region selected!")
-                raise Errors::VagrantGoogleError, "Specified disk type is not available and cannot be used!"
+                raise Errors::DiskTypeError,
+                  :disktype => disk_type
               end
             end
 

--- a/lib/vagrant-google/errors.rb
+++ b/lib/vagrant-google/errors.rb
@@ -20,6 +20,14 @@ module VagrantPlugins
         error_namespace("vagrant_google.errors")
       end
 
+      class ExternalIpError < VagrantGoogleError
+        error_key(:external_ip_error)
+      end
+
+      class DiskTypeError <VagrantGoogleError
+        error_key(:disk_type_error)
+      end
+
       class FogError < VagrantGoogleError
         error_key(:fog_error)
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -68,6 +68,13 @@ en:
         Host path: %{hostpath}
         Guest path: %{guestpath}
         Error: %{stderr}
+      external_ip_error: |-
+        Specified external IP address is invalid or already in use.
+        IP address requested: %{externalip}
+
+      disk_type_error: |-
+        Specified disk type is not available in the region selected.
+        Disk type requested: %{disktype}
 
     states:
       short_not_created: |-


### PR DESCRIPTION
Providing proper user-friendly and localized error handling as per official documentation:
https://github.com/mitchellh/vagrant/blob/master/lib/vagrant/errors.rb

Should fix confusing "Error => No error" messages in cases of incorrect resource specification described in #45. 