### PR TITLE
Adding support for JSON private keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider :google do |google, override|
     google.google_project_id = "YOUR_GOOGLE_CLOUD_PROJECT_ID"
     google.google_client_email = "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"
-    google.google_key_location = "/PATH/TO/YOUR/PRIVATE_KEY.p12"
+    google.google_json_key_location = "/path/to/your/private-key.json"
 
     override.ssh.username = "USERNAME"
     override.ssh.private_key_path = "~/.ssh/id_rsa"
@@ -139,7 +139,9 @@ configuration for this provider.
 This provider exposes quite a few provider-specific configuration options:
 
 * `google_client_email` - The Client Email address for your Service Account.
-* `google_key_location` - The location to the private key file matching your
+* `google_key_location` - The location of the P12 private key file matching your
+  Service Account.
+* `google_json_key_location` - The location of the JSON private key file matching your
   Service Account.
 * `google_project_id` - The Project ID for your Google Cloud Platform account.
 * `image` - The image name to use when booting your instance.
@@ -164,9 +166,9 @@ Vagrant.configure("2") do |config|
   # ... other stuff
 
   config.vm.provider :google do |google|
-    google.google_project_id = "my_project"
-    google.google_client_email = "hashstring@example.com"
-    google.google_key_location = "/tmp/private-key.p12"
+    google.google_project_id = "YOUR_GOOGLE_CLOUD_PROJECT_ID"
+    google.google_client_email = "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"
+    google.google_json_key_location = "/path/to/your/private-key.json"
   end
 end
 ```
@@ -182,9 +184,9 @@ Vagrant.configure("2") do |config|
   config.vm.box = "gce"
 
   config.vm.provider :google do |google|
-    google.google_project_id = "my_project"
-    google.google_client_email = "hashstring@example.com"
-    google.google_key_location = "/tmp/private-key.p12"
+    google.google_project_id = "YOUR_GOOGLE_CLOUD_PROJECT_ID"
+    google.google_client_email = "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"
+    google.google_json_key_location = "/path/to/your/private-key.json"
 
     # Make sure to set this to trigger the zone_config
     google.zone = "us-central1-f"

--- a/lib/vagrant-google/action/connect_google.rb
+++ b/lib/vagrant-google/action/connect_google.rb
@@ -29,13 +29,21 @@ module VagrantPlugins
         def call(env)
           provider_config = env[:machine].provider_config
 
-          # Build the fog config
-          fog_config = {
-            :provider            => :google,
-            :google_project      => provider_config.google_project_id,
-            :google_client_email => provider_config.google_client_email,
-            :google_key_location => provider_config.google_key_location
-          }
+          unless provider_config.google_json_key_location.nil?
+            fog_config = {
+              :provider            => :google,
+              :google_project      => provider_config.google_project_id,
+              :google_client_email => provider_config.google_client_email,
+              :google_json_key_location => provider_config.google_json_key_location
+            }
+          else
+            fog_config = {
+              :provider            => :google,
+              :google_project      => provider_config.google_project_id,
+              :google_client_email => provider_config.google_client_email,
+              :google_key_location => provider_config.google_key_location
+            }
+          end
 
           @logger.info("Connecting to Google...")
           env[:google_compute] = Fog::Compute.new(fog_config)

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -26,6 +26,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :google_key_location
 
+      # The path to the Service Account json-formatted private key
+      #
+      # @return [String]
+      attr_accessor :google_json_key_location
+
       # The Google Cloud Project ID (not name or number)
       #
       # @return [String]
@@ -111,6 +116,7 @@ module VagrantPlugins
       def initialize(zone_specific=false)
         @google_client_email = UNSET_VALUE
         @google_key_location = UNSET_VALUE
+        @google_json_key_location = UNSET_VALUE
         @google_project_id   = UNSET_VALUE
         @image               = UNSET_VALUE
         @machine_type        = UNSET_VALUE
@@ -200,6 +206,7 @@ module VagrantPlugins
         # will default to nil if the environment variables are not present.
         @google_client_email = ENV['GOOGLE_CLIENT_EMAIL'] if @google_client_email == UNSET_VALUE
         @google_key_location = ENV['GOOGLE_KEY_LOCATION'] if @google_key_location == UNSET_VALUE
+        @google_json_key_location = ENV['GOOGLE_JSON_KEY_LOCATION'] if @google_json_key_location == UNSET_VALUE
         @google_project_id   = ENV['GOOGLE_PROJECT_ID'] if @google_project_id == UNSET_VALUE
 
         # Image must be nil, since we can't default that
@@ -226,7 +233,7 @@ module VagrantPlugins
 
         # Default zone is us-central1-f.
         @zone = "us-central1-f" if @zone == UNSET_VALUE
-        
+
         # autodelete_disk defaults to true
         @autodelete_disk = true if @autodelete_disk == UNSET_VALUE
 
@@ -276,8 +283,11 @@ module VagrantPlugins
             config.google_project_id.nil?
           errors << I18n.t("vagrant_google.config.google_client_email_required") if \
             config.google_client_email.nil?
+          errors << I18n.t("vagrant_google.config.google_duplicate_key_location") if \
+            !config.google_key_location.nil? and !config.google_json_key_location.nil?
           errors << I18n.t("vagrant_google.config.google_key_location_required") if \
-            config.google_key_location.nil?
+            config.google_key_location.nil? and config.google_json_key_location.nil?
+
         end
 
         errors << I18n.t("vagrant_google.config.image_required") if config.image.nil?

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -46,7 +46,13 @@ en:
       name_required: |-
         An instance name must be specified via "name"
       google_key_location_required: |-
-        A private key pathname is required via "google_key_location"
+        A private key pathname is required via:
+         "google_json_key_location" (for JSON keys)
+         or
+         "google_key_location" (for P12 keys)
+      google_duplicate_key_location: |-
+        Both "google_json_key_location" and "google_key_location" are specified.
+        Config must specify only one key location.
       google_project_id_required: |-
         A Google Cloud Project ID is required via "google_project_id"
 

--- a/spec/vagrant-google/config_spec.rb
+++ b/spec/vagrant-google/config_spec.rb
@@ -88,6 +88,30 @@ describe VagrantPlugins::Google::Config do
       its("google_key_location") { should == "/path/to/key" }
       its("google_json_key_location") { should == "/path/to/json/key" }
     end
+
+    context "With both Google credential environment variables" do
+      before :each do
+        ENV.stub(:[]).with("GOOGLE_CLIENT_EMAIL").and_return("client_id_email")
+        ENV.stub(:[]).with("GOOGLE_KEY_LOCATION").and_return("/path/to/key")
+        ENV.stub(:[]).with("GOOGLE_JSON_KEY_LOCATION").and_return("/path/to/json/key")
+      end
+
+      it "Should return duplicate key location errors" do
+        instance.finalize!
+        expect(instance.validate("foo")["Google Provider"][1]).to include("en.vagrant_google.config.google_duplicate_key_location")
+      end
+    end
+
+    context "With none of the Google credential environment variables set" do
+      before :each do
+        ENV.stub(:[]).with("GOOGLE_CLIENT_EMAIL").and_return("client_id_email")
+      end
+
+      it "Should return no key set errors" do
+        instance.finalize!
+        expect(instance.validate("foo")["Google Provider"][1]).to include("en.vagrant_google.config.google_key_location_required")
+      end
+    end
   end
 
   describe "zone config" do

--- a/spec/vagrant-google/config_spec.rb
+++ b/spec/vagrant-google/config_spec.rb
@@ -20,7 +20,7 @@ describe VagrantPlugins::Google::Config do
   before :each do
     ENV.stub(:[] => nil)
   end
-  
+
   describe "defaults" do
     subject do
       instance.tap do |o|
@@ -68,12 +68,14 @@ describe VagrantPlugins::Google::Config do
 
       its("google_client_email") { should be_nil }
       its("google_key_location") { should be_nil }
+      its("google_json_key_location") { should be_nil }
     end
 
     context "with Google credential environment variables" do
       before :each do
         ENV.stub(:[]).with("GOOGLE_CLIENT_EMAIL").and_return("client_id_email")
         ENV.stub(:[]).with("GOOGLE_KEY_LOCATION").and_return("/path/to/key")
+        ENV.stub(:[]).with("GOOGLE_JSON_KEY_LOCATION").and_return("/path/to/json/key")
       end
 
       subject do
@@ -84,6 +86,7 @@ describe VagrantPlugins::Google::Config do
 
       its("google_client_email") { should == "client_id_email" }
       its("google_key_location") { should == "/path/to/key" }
+      its("google_json_key_location") { should == "/path/to/json/key" }
     end
   end
 

--- a/vagrantfile_examples/Vagrantfile.multiple_machines
+++ b/vagrantfile_examples/Vagrantfile.multiple_machines
@@ -25,7 +25,7 @@
 # Customize these global variables
 $GOOGLE_PROJECT_ID = "YOUR_GOOGLE_CLOUD_PROJECT_ID"
 $GOOGLE_CLIENT_EMAIL = "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"
-$GOOGLE_KEY_LOCATION = "/PATH/TO/YOUR/PRIVATE_KEY.p12"
+$GOOGLE_JSON_KEY_LOCATION = "/path/to/your/private-key.json"
 $LOCAL_USER = "mitchellh"
 $LOCAL_SSH_KEY = "~/.ssh/id_rsa"
 
@@ -55,7 +55,7 @@ Vagrant.configure("2") do |config|
     z1a.vm.provider :google do |google, override|
       google.google_project_id = $GOOGLE_PROJECT_ID
       google.google_client_email = $GOOGLE_CLIENT_EMAIL
-      google.google_key_location = $GOOGLE_KEY_LOCATION
+      google.google_json_key_location = $GOOGLE_JSON_KEY_LOCATION
       google.zone = "us-central1-a"
 
       override.ssh.username = $LOCAL_USER
@@ -75,7 +75,7 @@ Vagrant.configure("2") do |config|
     z1b.vm.provider :google do |google, override|
       google.google_project_id = $GOOGLE_PROJECT_ID
       google.google_client_email = $GOOGLE_CLIENT_EMAIL
-      google.google_key_location = $GOOGLE_KEY_LOCATION
+      google.google_json_key_location = $GOOGLE_JSON_KEY_LOCATION
       google.zone = "us-central1-b"
 
       override.ssh.username = $LOCAL_USER

--- a/vagrantfile_examples/Vagrantfile.provision_single
+++ b/vagrantfile_examples/Vagrantfile.provision_single
@@ -21,7 +21,7 @@
 # Customize these global variables
 $GOOGLE_PROJECT_ID = "YOUR_GOOGLE_CLOUD_PROJECT_ID"
 $GOOGLE_CLIENT_EMAIL = "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"
-$GOOGLE_KEY_LOCATION = "/PATH/TO/YOUR/PRIVATE_KEY.p12"
+$GOOGLE_JSON_KEY_LOCATION = "/path/to/your/private-key.json"
 $LOCAL_USER = "mitchellh"
 $LOCAL_SSH_KEY = "~/.ssh/id_rsa"
 
@@ -32,7 +32,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider :google do |google, override|
     google.google_project_id = $GOOGLE_PROJECT_ID
     google.google_client_email = $GOOGLE_CLIENT_EMAIL
-    google.google_key_location = $GOOGLE_KEY_LOCATION
+    google.google_json_key_location = $GOOGLE_JSON_KEY_LOCATION
 
     # Override provider defaults
     google.name = "testing-vagrant"

--- a/vagrantfile_examples/Vagrantfile.simple
+++ b/vagrantfile_examples/Vagrantfile.simple
@@ -20,7 +20,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider :google do |google, override|
     google.google_project_id = "YOUR_GOOGLE_CLOUD_PROJECT_ID"
     google.google_client_email = "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"
-    google.google_key_location = "/PATH/TO/YOUR/PRIVATE_KEY.p12"
+    google.google_json_key_location = "/path/to/your/private-key.json"
 
     override.ssh.username = "mitchellh"
     override.ssh.private_key_path = "~/.ssh/id_rsa"

--- a/vagrantfile_examples/Vagrantfile.zone_config
+++ b/vagrantfile_examples/Vagrantfile.zone_config
@@ -20,7 +20,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider :google do |google, override|
     google.google_project_id = "YOUR_GOOGLE_CLOUD_PROJECT_ID"
     google.google_client_email = "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"
-    google.google_key_location = "/PATH/TO/YOUR/PRIVATE_KEY.p12"
+    google.google_json_key_location = "/path/to/your/private-key.json"
 
     override.ssh.username = "mitchellh"
     override.ssh.private_key_path = "~/.ssh/id_rsa"


### PR DESCRIPTION
Adding support for JSON private keys in vagrant-google. Issue tracked in #41
Has been tested with Vagrant 1.7.5 in dev. All relevant tests, docs and error messages are updated to include the new parameter.
The new parameter is called google_json_key_location not to break existing Vagrantfiles.

/cc @erjohnso 
I've got 2 notes for this request:
1) I am not entirely sure where the GOOGLE_KEY_LOCATION environment variable comes from. There's no reference of it in Fog/gcloud/API docs. I set the json one to source from GOOGLE_JSON_KEY_LOCATION, is that ok?
2) I changed the logic for the key selection a bit and covered new validation scenarios (both keys populated, both keys empty). Still I'm getting a feeling that this needs a unit test as well to make sure errors are always correctly raised. Do you think so too? Or do we just cover this in acceptance/integration tests later?
If you do, however, I didn't find an easy way to mock the config for the instance.validate method.
Even if I blatantly copy the working ENV test and insert a validation test in there, it's still passes (instance._detected_errors returns []):
 ```
    context "with Google credential environment variables" do
      before :each do
        ENV.stub(:[]).with("GOOGLE_CLIENT_EMAIL").and_return("client_id_email")
        ENV.stub(:[]).with("GOOGLE_KEY_LOCATION").and_return("/path/to/key")
        ENV.stub(:[]).with("GOOGLE_JSON_KEY_LOCATION").and_return("/path/to/json/key")
      end

      subject do
        instance.tap do |o|
          o.finalize!
        end
        instance.validate("foo")
        instance._detected_errors
      end

      it "Should return errors" do
        expect(instance._detected_errors).not_to be_empty
      end

    end
```
Since I'm a bit new to writing rspec tests, I fully accept that I may be doing something wrong, however, I do not see what exactly. Can you point me in the right direction on it?