### PR TITLE
Disable asyncronous execution on termination.

### DIFF
--- a/lib/vagrant-google/action/terminate_instance.rb
+++ b/lib/vagrant-google/action/terminate_instance.rb
@@ -27,8 +27,9 @@ module VagrantPlugins
           server = env[:google_compute].servers.get(env[:machine].id, env[:machine].provider_config.zone)
 
           # Destroy the server and remove the tracking ID
+          # destroy() is called with 'false' to disable asynchronous execution.
           env[:ui].info(I18n.t("vagrant_google.terminating"))
-          server.destroy if not server.nil?
+          server.destroy(false) if not server.nil?
           env[:machine].id = nil
 
           @app.call(env)


### PR DESCRIPTION
Fixing #44. 

This is due to fog-google implementing all operations in asynchronous mode by default.
In this case, server.destroy. Setting server.destroy(false) waits for the instance to be terminated, correcting this behaviour.