### PR TITLE
Adding existence checks on destroy.

### DIFF
--- a/lib/vagrant-google/action.rb
+++ b/lib/vagrant-google/action.rb
@@ -25,8 +25,14 @@ module VagrantPlugins
           b.use Call, DestroyConfirm do |env, b2|
             if env[:result]
               b2.use ConfigValidate
-              b2.use ConnectGoogle
-              b2.use TerminateInstance
+              b2.use Call, IsCreated do |env2, b3|
+                if !env2[:result]
+                  b3.use MessageNotCreated
+                  next
+                end
+                b3.use ConnectGoogle
+                b3.use TerminateInstance
+              end
             else
               b2.use MessageWillNotDestroy
             end


### PR DESCRIPTION
Now one cannot cause a backtrace by invoking destroy 2 times.
Fixing #50.

/CC @erjohnso 