### PR TITLE
Fixing excludes, adding Vagrantfiles for box builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,5 @@ Gemfile.lock
 
 # Vagrant
 .vagrant
-Vagrantfile*
-!example_box/Vagrantfile
-!vagrantfile_examples/*
+/Vagrantfile*
+

--- a/example_boxes/gce-test/Vagrantfile
+++ b/example_boxes/gce-test/Vagrantfile
@@ -1,0 +1,30 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+# Copyright 2013 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Vagrant.configure("2") do |config|
+  config.vm.provider :google do |google, override|
+
+    if ENV['GOOGLE_SSH_USER'] and ENV['GOOGLE_SSH_KEY_LOCATION']
+      override.ssh.username = ENV['GOOGLE_SSH_USER']
+      override.ssh.private_key_path = ENV['GOOGLE_SSH_KEY_LOCATION']
+    end
+
+    google.image = "debian-7-wheezy-v20150127"
+    google.machine_type = "n1-standard-1"
+    google.zone = "us-central1-f"
+
+  end
+end

--- a/example_boxes/gce/Vagrantfile
+++ b/example_boxes/gce/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+# Copyright 2013 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Vagrant.configure("2") do |config|
+  config.vm.provider :google do |google|
+    google.image = "debian-7-wheezy-v20150127"
+    google.machine_type = "n1-standard-1"
+    google.zone = "us-central1-f"
+  end
+end


### PR DESCRIPTION
Vagrantfiles for building test boxes got excluded when I changed the repo structure. 
Should be fixed now.

/CC @erjohnso 