### PR TITLE
Adding SSH key warnings to run_instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,25 @@ Note that you can use the more standard `~/.ssh/id_rsa[.pub]` files, but you
 will need to manually add your public key to the GCE metadata service so your
 VMs will pick up the the key. Note that they public key is typically
 prefixed with the username, so that the daemon on the VM adds the public key
-to the correct user account.  See the blow links for more help with SSH and
-GCE VMs.
+to the correct user account.
+
+Additionally, you will probably need to add the key and username to override
+settings in your Vagrantfile like so:
+
+```ruby
+config.vm.provider :google do |google, override|
+    
+    #...google provider settings are skipped...
+    
+    override.ssh.username = "testuser"
+    override.ssh.private_key_path = "~/.ssh/id_rsa"
+    
+    #...google provider settings are skipped...
+
+end
+```
+
+See the links below for more help with SSH and GCE VMs.
 
   * https://cloud.google.com/compute/docs/instances#sshing
   * https://cloud.google.com/compute/docs/console#sshkeys

--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -66,6 +66,10 @@ module VagrantPlugins
           env[:ui].info(" -- Autodelete Disk: #{autodelete_disk}")
           begin
             request_start_time = Time.now().to_i
+            #Warn on ssh-key overrides
+            if env[:machine].config.ssh.username.nil?
+               env[:ui].warn(I18n.t("vagrant_google.warn_ssh_vagrant_user"))
+            end
             #Check if specified external ip is available
             if !external_ip.nil?
               address = env[:google_compute].addresses.get_by_ip_address(external_ip)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -33,6 +33,14 @@ en:
       Warning! The Google provider doesn't support any of the Vagrant
       high-level network configurations (`config.vm.network`). They
       will be silently ignored.
+    warn_ssh_vagrant_user: |-
+      Warning! SSH credentials are not set (`ssh.username`, `ssh.private_key`).
+      Unless Vagrant's default insecure private key is added to GCE metadata,
+      "vagrant up" will timeout while trying to estabilish an ssh connection
+      to the instance.
+      NOTE! Adding Vagrant private key to GCE metadata is heavily discouraged,
+      since it potentially allows anyone to connect to your instances, 
+      including those not managed by Vagrant.  
     will_not_destroy: |-
       The instance '%{name}' will not be destroyed, since the confirmation
       was declined.


### PR DESCRIPTION
This commit adds SSH key warnings, closing #49 

/CC @erjohnso 

Hi Eric,

Before you merge, I want to hear your input on this.
This will now produce warnings if the ssh key path and user are not set in Vagrantfile.
Warning is the following:
```
    Warning! The SSH credentials are not set. Unless the insecure private
    key is added to GCE metadata (heavily discouraged), the ssh connection
    to the instance will fail.
```
Is this enough or should we not mention potentially harmful actions (adding public private keys to GCE metadata) at all? I added it because I can see someone doing this if the machines are firewalled and are brought up only for short testing on a separate account.