### PR TITLE
Fix network warnings

### DIFF
--- a/lib/vagrant-google/action/warn_networks.rb
+++ b/lib/vagrant-google/action/warn_networks.rb
@@ -20,7 +20,8 @@ module VagrantPlugins
         end
 
         def call(env)
-          if env[:machine].config.vm.networks.length > 0
+          #Default SSH forward always exists so "> 1"
+          if env[:machine].config.vm.networks.length > 1
             env[:ui].warn(I18n.t("vagrant_google.warn_networks"))
           end
 


### PR DESCRIPTION
Fixing #63 - unnecessary network warnings that are always triggered by default rule.

/CC @erjohnso 
With the #64, a sanely configured Vagrantfile now produces a pretty warning-free output:
```
Bringing machine 'default' up with 'google' provider...
==> default: Launching an instance with the following settings...
==> default:  -- Name:            testing-vagrant
==> default:  -- Type:            n1-standard-1
==> default:  -- Disk type:       pd-ssd
==> default:  -- Disk size:       10 GB
==> default:  -- Disk name:
==> default:  -- Image:           debian-7-wheezy-v20150127
==> default:  -- Zone:            europe-west1-d
==> default:  -- Network:         default
==> default:  -- Metadata:        '{}'
==> default:  -- Tags:            '[]'
==> default:  -- IP Forward:
==> default:  -- External IP:
==> default:  -- Autodelete Disk: true
==> default: Waiting for instance to become "ready"...
```
<img alt="Bear" src="http://i.imgur.com/wQf7cdZ.gif" />