### PR TITLE
Adds support for service account definitions.

### DIFF
--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -48,6 +48,7 @@ module VagrantPlugins
           can_ip_forward     = zone_config.can_ip_forward
           external_ip        = zone_config.external_ip
           autodelete_disk    = zone_config.autodelete_disk
+          service_accounts   = zone_config.service_accounts
 
           # Launch!
           env[:ui].info(I18n.t("vagrant_google.launching_instance"))
@@ -64,6 +65,7 @@ module VagrantPlugins
           env[:ui].info(" -- IP Forward:      #{can_ip_forward}")
           env[:ui].info(" -- External IP:     #{external_ip}")
           env[:ui].info(" -- Autodelete Disk: #{autodelete_disk}")
+          env[:ui].info(" -- Scopes:    #{service_accounts}")
           begin
             request_start_time = Time.now().to_i
             #Warn on ssh-key overrides
@@ -129,6 +131,7 @@ module VagrantPlugins
               :can_ip_forward     => can_ip_forward,
               :external_ip        => external_ip,
               :disks              => [disk.get_as_boot_disk(true, autodelete_disk)],
+              :service_accounts   => service_accounts,
             }
             server = env[:google_compute].servers.create(defaults)
             @logger.info("Machine '#{zone}:#{name}' created.")

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -113,6 +113,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :zone
 
+      # The list of access controls for service accounts.
+      #
+      # @return [Array]
+      attr_accessor :service_accounts
+
       def initialize(zone_specific=false)
         @google_client_email = UNSET_VALUE
         @google_key_location = UNSET_VALUE
@@ -132,6 +137,7 @@ module VagrantPlugins
         @autodelete_disk     = UNSET_VALUE
         @instance_ready_timeout = UNSET_VALUE
         @zone                = UNSET_VALUE
+        @service_accounts    = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -245,6 +251,9 @@ module VagrantPlugins
 
         # Default instance_ready_timeout
         @instance_ready_timeout = 20 if @instance_ready_timeout == UNSET_VALUE
+
+        # Default service_accounts
+        @service_accounts = nil if @service_accounts == UNSET_VALUE
 
         # Compile our zone specific configurations only within
         # NON-zone-SPECIFIC configurations.

--- a/test/unit/common/config_test.rb
+++ b/test/unit/common/config_test.rb
@@ -42,6 +42,7 @@ describe VagrantPlugins::Google::Config do
     its("instance_ready_timeout") { should == 20 }
     its("metadata")          { should == {} }
     its("tags")              { should == [] }
+    its("service_accounts")  { should == nil }
   end
 
   describe "overriding defaults" do


### PR DESCRIPTION
This PR should add support for specifying the service account name, to permit a GCloud box to use GCloud APIs itself.