### PR TITLE
Switching to fog-google metagem

### DIFF
--- a/lib/vagrant-google/action/connect_google.rb
+++ b/lib/vagrant-google/action/connect_google.rb
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-require "fog"
+require "fog/google"
 require "log4r"
 
 module VagrantPlugins

--- a/vagrant-google.gemspec
+++ b/vagrant-google.gemspec
@@ -28,10 +28,10 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-google"
 
-  s.add_runtime_dependency "fog", "1.29"
+  s.add_runtime_dependency "fog-google", "0.0.5"
   s.add_runtime_dependency "google-api-client"
   #s.add_runtime_dependency "pry"
-  #s.add_runtime_dependency "pry-nav"
+  #s.add_runtime_dependency "pry-byebug"
   #s.add_runtime_dependency "rb-readline"
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
Switching to fog-google in preparation for 0.2.0 release.
Acceptance tests pass, LGTM.

Small stuff:
- Switching to pry-byebug from pry-nav

/CC @erjohnso 