### PR TITLE
Adding custom acceptance tests

### DIFF
--- a/tasks/acceptance.rake
+++ b/tasks/acceptance.rake
@@ -1,3 +1,17 @@
+def colorize(text, color_code)
+    puts "\033[#{color_code}m#{text}\033[0m"
+end
+
+{
+:red      => 31,
+:green    => 32,
+:yellow   => 33,
+}.each do |key, color_code|
+  define_method key do |text|
+    colorize(text, color_code)
+  end
+end
+
 namespace :acceptance do
 
   desc "shows components that can be tested separately"
@@ -8,7 +22,7 @@ namespace :acceptance do
   desc "runs acceptance tests using vagrant-spec"
   task :run do
 
-    puts "NOTE: For acceptance tests to be functional, correct ssh key needs to be added to GCE metadata."
+    yellow "NOTE: For acceptance tests to be functional, correct ssh key needs to be added to GCE metadata.\033[0m"
 
     if !ENV["GOOGLE_JSON_KEY_LOCATION"] && !ENV["GOOGLE_KEY_LOCATION"]
       abort ("Environment variables GOOGLE_JSON_KEY_LOCATION or GOOGLE_KEY_LOCATION are not set. Aborting.")
@@ -27,7 +41,10 @@ namespace :acceptance do
     end
 
     components = %w(
+      scopes
+      multi_instance
       provisioner/shell
+      provisioner/chef-solo
     ).map{ |s| "provider/google/#{s}" }
 
     command = "bundle exec vagrant-spec test --components=#{components.join(" ")}"

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -4,5 +4,6 @@ require 'rspec/core/rake_task'
 namespace :test do
   RSpec::Core::RakeTask.new(:unit) do |t|
     t.pattern = "test/unit/**/*_test.rb"
+    t.rspec_opts = "--color"
   end
 end

--- a/test/acceptance/provider/multi_instance_spec.rb
+++ b/test/acceptance/provider/multi_instance_spec.rb
@@ -1,0 +1,31 @@
+# This tests that multiple instances can be brought up correctly
+shared_examples 'provider/multi_instance' do |provider, options|
+  if !options[:box]
+    raise ArgumentError,
+      "box option must be specified for provider: #{provider}"
+  end
+
+  include_context 'acceptance'
+
+  before do
+    environment.skeleton('multi_instance')
+    assert_execute('vagrant', 'box', 'add', 'basic', options[:box])
+    assert_execute('vagrant', 'up', "--provider=#{provider}")
+  end
+
+  after do
+    assert_execute('vagrant', 'destroy', '--force')
+  end
+
+  it 'should bring up 2 machines in different zones' do
+    status("Test: both machines are running after up")
+    status("Test: machine1 is running after up")
+    result1 = execute("vagrant", "ssh", "z1a", "-c", "echo foo")
+    expect(result1).to exit_with(0)
+    expect(result1.stdout).to match(/foo\n$/)
+    status("Test: machine2 is running after up")
+    result1 = execute("vagrant", "ssh", "z1b", "-c", "echo foo")
+    expect(result1).to exit_with(0)
+    expect(result1.stdout).to match(/foo\n$/)
+  end
+end

--- a/test/acceptance/provider/scopes_spec.rb
+++ b/test/acceptance/provider/scopes_spec.rb
@@ -1,0 +1,26 @@
+# This tests that account scopes can be configured correctly
+shared_examples 'provider/scopes' do |provider, options|
+  if !options[:box]
+    raise ArgumentError,
+      "box option must be specified for provider: #{provider}"
+  end
+
+  include_context 'acceptance'
+
+  before do
+    environment.skeleton('scopes')
+    assert_execute('vagrant', 'box', 'add', 'basic', options[:box])
+    assert_execute('vagrant', 'up', "--provider=#{provider}")
+  end
+
+  after do
+    assert_execute('vagrant', 'destroy', '--force')
+  end
+
+  it 'should bring up machine with scope definitions' do
+    status("Test: machine is running after up")
+    result = execute("vagrant", "ssh", "-c", "echo foo")
+    expect(result).to exit_with(0)
+    expect(result.stdout).to match(/foo\n$/)
+  end
+end

--- a/test/acceptance/skeletons/multi_instance/Vagrantfile
+++ b/test/acceptance/skeletons/multi_instance/Vagrantfile
@@ -1,0 +1,29 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "basic"
+
+  config.vm.define :z1a do |z1a|
+    z1a.vm.provider :google do |google, override|
+      google.zone = "europe-west1-c"
+
+      google.zone_config "europe-west1-c" do |z1a_zone|
+        z1a_zone.name = "vagrant-testing-acceptance-multi-z1a"
+        z1a_zone.image = "debian-7-wheezy-v20150603"
+        z1a_zone.machine_type = "n1-standard-1"
+        z1a_zone.zone = "europe-west1-c"
+      end
+    end
+  end
+
+  config.vm.define :z1b do |z1b|
+    z1b.vm.provider :google do |google, override|
+      google.zone = "europe-west1-d"
+
+      google.zone_config "europe-west1-d" do |z1b_zone|
+        z1b_zone.name = "vagrant-testing-acceptance-multi-z1b"
+        z1b_zone.image = "debian-7-wheezy-v20150603"
+        z1b_zone.machine_type = "n1-standard-2"
+        z1b_zone.zone = "europe-west1-d"
+      end
+    end
+  end
+end

--- a/test/acceptance/skeletons/scopes/Vagrantfile
+++ b/test/acceptance/skeletons/scopes/Vagrantfile
@@ -1,0 +1,15 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "basic"
+
+  config.vm.provider :google do |google, override|
+
+    google.zone = "europe-west1-d"
+
+    google.zone_config "europe-west1-d" do |zone1d|
+        zone1d.name = "vagrant-testing-acceptance-scopes"
+        zone1d.service_accounts = ['bigquery', 'https://www.googleapis.com/auth/compute']
+        zone1d.image = "debian-7-wheezy-v20150603"
+        zone1d.zone = "europe-west1-d"
+    end
+  end
+end

--- a/vagrantfile_examples/Vagrantfile.multiple_machines
+++ b/vagrantfile_examples/Vagrantfile.multiple_machines
@@ -18,9 +18,9 @@
 #  1) Launch both instances and then destroy both
 #     $ vagrant up --provider=google
 #     $ vagrant destroy
-#  2) Launch one instance 'z1a' and then destory the same
-#     $ vagrant up z1a --provider=google
-#     $ vagrant destroy z1a
+#  2) Launch one instance 'z1c' and then destory the same
+#     $ vagrant up z1c --provider=google
+#     $ vagrant destroy z1c
 
 # Customize these global variables
 $GOOGLE_PROJECT_ID = "YOUR_GOOGLE_CLOUD_PROJECT_ID"
@@ -51,44 +51,43 @@ Vagrant.configure("2") do |config|
   config.vm.box = "gce"
   config.vm.provision :shell, :inline => $PROVISION_DEBIAN
 
-  config.vm.define :z1a do |z1a|
-    z1a.vm.provider :google do |google, override|
+  config.vm.define :z1c do |z1c|
+    z1c.vm.provider :google do |google, override|
       google.google_project_id = $GOOGLE_PROJECT_ID
       google.google_client_email = $GOOGLE_CLIENT_EMAIL
       google.google_json_key_location = $GOOGLE_JSON_KEY_LOCATION
-      google.zone = "us-central1-a"
+      google.zone = "us-central1-c"
 
       override.ssh.username = $LOCAL_USER
       override.ssh.private_key_path = $LOCAL_SSH_KEY
 
-      google.zone_config "us-central1-a" do |z1a_zone|
-        z1a_zone.name = "z1a"
-        z1a_zone.image = "debian-7-wheezy-v20150127"
-        z1a_zone.machine_type = "n1-standard-1"
-        z1a_zone.zone = "us-central1-a"
-        z1a_zone.metadata = {"zone" => "US Central 1a"}
+      google.zone_config "us-central1-c" do |z1c_zone|
+        z1c_zone.name = "z1c"
+        z1c_zone.image = "debian-7-wheezy-v20150603"
+        z1c_zone.machine_type = "n1-standard-1"
+        z1c_zone.zone = "us-central1-c"
+        z1c_zone.metadata = {"zone" => "US Central 1c"}
       end
     end
   end
 
-  config.vm.define :z1b do |z1b|
-    z1b.vm.provider :google do |google, override|
+  config.vm.define :z1f do |z1f|
+    z1f.vm.provider :google do |google, override|
       google.google_project_id = $GOOGLE_PROJECT_ID
       google.google_client_email = $GOOGLE_CLIENT_EMAIL
       google.google_json_key_location = $GOOGLE_JSON_KEY_LOCATION
-      google.zone = "us-central1-b"
+      google.zone = "us-central1-f"
 
       override.ssh.username = $LOCAL_USER
       override.ssh.private_key_path = $LOCAL_SSH_KEY
 
-      google.zone_config "us-central1-b" do |z1b_zone|
-        z1b_zone.name = "z1b"
-        z1b_zone.image = "debian-7-wheezy-v20150127"
-        z1b_zone.machine_type = "n1-standard-2"
-        z1b_zone.zone = "us-central1-b"
-        z1b_zone.metadata = {"zone" => "US Central 1b"}
+      google.zone_config "us-central1-f" do |z1f_zone|
+        z1f_zone.name = "z1f"
+        z1f_zone.image = "debian-7-wheezy-v20150603"
+        z1f_zone.machine_type = "n1-standard-2"
+        z1f_zone.zone = "us-central1-f"
+        z1f_zone.metadata = {"zone" => "US Central 1f"}
       end
-
     end
   end
 end

--- a/vagrantfile_examples/Vagrantfile.provision_single
+++ b/vagrantfile_examples/Vagrantfile.provision_single
@@ -36,9 +36,9 @@ Vagrant.configure("2") do |config|
 
     # Override provider defaults
     google.name = "testing-vagrant"
-    google.image = "debian-7-wheezy-v20150127"
+    google.image = "debian-7-wheezy-v20150603"
     google.machine_type = "n1-standard-1"
-    google.zone = "us-central1-a"
+    google.zone = "us-central1-f"
     google.metadata = {'custom' => 'metadata', 'testing' => 'foobarbaz'}
     google.tags = ['vagrantbox', 'dev']
 

--- a/vagrantfile_examples/Vagrantfile.zone_config
+++ b/vagrantfile_examples/Vagrantfile.zone_config
@@ -26,13 +26,13 @@ Vagrant.configure("2") do |config|
     override.ssh.private_key_path = "~/.ssh/id_rsa"
 
     # Make sure to set this to trigger the zone_config
-    google.zone = "us-central1-a"
+    google.zone = "us-central1-f"
 
-    google.zone_config "us-central1-a" do |zone1a|
+    google.zone_config "us-central1-f" do |zone1a|
         zone1a.name = "testing-vagrant"
-        zone1a.image = "debian-7-wheezy-v20150127"
+        zone1a.image = "debian-7-wheezy-v20150603"
         zone1a.machine_type = "n1-standard-4"
-        zone1a.zone = "us-central1-a"
+        zone1a.zone = "us-central1-f"
         zone1a.scopes = ['bigquery', 'monitoring', 'https://www.googleapis.com/auth/compute']
         zone1a.metadata = {'custom' => 'metadata', 'testing' => 'foobarbaz'}
     end


### PR DESCRIPTION
Finally sat down and coded some custom acceptance tests so I don't have to run those corner-cases manually again :)

Those test the correct account scope configuration and correct set up of multiple machines.
They can be used as a template for more custom acceptance tests in the future.

Rake acceptance run now looks like this:
```
temikus λ rake acceptance:run
NOTE: For acceptance tests to be functional, correct ssh key needs to be added to GCE metadata.
bundle exec vagrant-spec test --components=provider/google/scopes provider/google/multi_instance provider/google/provisioner/shell provider/google/provisioner/chef-solo

Skipping: cli/box
Skipping: cli/init
Skipping: cli/plugin
Skipping: cli/version
Skipping: provider/google/basic
Skipping: provider/google/network/forwarded_port
Skipping: provider/google/network/private_network
Skipping: provider/google/package
Skipping: provider/google/synced_folder
Skipping: provider/google/provisioner/puppet
Skipping: provider/google/synced_folder/nfs
Skipping: provider/google/synced_folder/rsync

provider/google/provisioner/chef-solo
  it should behave like provider/provisioner/chef-solo
    provisions with chef-solo
      Execute: vagrant box add box https://github.com/mitchellh/vagrant-google/raw/master/google-test.box
      Execute: vagrant up --provider=google
      Test: basic cookbooks and recipes
      Execute: vagrant ssh -c cat /vagrant-chef-basic
      Test: works with roles
      Execute: vagrant ssh -c cat /vagrant-chef-basic-roles
      Execute: vagrant destroy --force
      provisions with chef-solo

provider/google/provisioner/shell
  it should behave like provider/provisioner/shell
    provisions with the shell script
      Execute: vagrant box add box https://github.com/mitchellh/vagrant-google/raw/master/google-test.box
      Execute: vagrant up --provider=google
      Test: inline script
      Execute: vagrant ssh -c cat /foo
      Test: script from path
      Execute: vagrant ssh -c cat /vagrant-path
      Test: script with args
      Execute: vagrant ssh -c cat /vagrant-args
      Test: privileged scripts
      Execute: vagrant ssh -c cat /tmp/vagrant-user-root
      Test: non-privileged scripts
      Execute: vagrant ssh -c cat /tmp/vagrant-user
      Execute: vagrant destroy --force
      provisions with the shell script

provider/google/multi_instance
  it should behave like provider/multi_instance
    should bring up 2 machines in different zones
      Execute: vagrant box add basic https://github.com/mitchellh/vagrant-google/raw/master/google-test.box
      Execute: vagrant up --provider=google
      Test: both machines are running after up
      Test: machine1 is running after up
      Execute: vagrant ssh z1a -c echo foo
      Test: machine2 is running after up
      Execute: vagrant ssh z1b -c echo foo
      Execute: vagrant destroy --force
      should bring up 2 machines in different zones

provider/google/scopes
  it should behave like provider/scopes
    should bring up machine with scope definitions
      Execute: vagrant box add basic https://github.com/mitchellh/vagrant-google/raw/master/google-test.box
      Execute: vagrant up --provider=google
      Test: machine is running after up
      Execute: vagrant ssh -c echo foo
      Execute: vagrant destroy --force
      should bring up machine with scope definitions

Finished in 10 minutes 13 seconds
4 examples, 0 failures
```