### PR TITLE
Temporarily reverting the SyncedFolders action support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.1 (July 2015)
+
+* Temporarily reverted the old SyncedFolders behaviour. (See #94)
+
 # 0.2.0 (July 2015)
 
 * Added support for service account definitions [tcr]

--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ This provider exposes quite a few provider-specific configuration options:
 * `can_ip_forward` - Boolean whether to enable IP Forwarding.
 * `external_ip` - The external IP address to use (supports names).
 * `preemptible` - Boolean whether to enable preemptibility. Default is false.
-* `auto_restart` - Boolean whether to enable auto_restart. Default is true.
-* `on_host_maintenance` - What to do on host maintenance. Default is "MIGRATE".
+* `auto_restart` - Boolean whether to enable auto_restart. Default is true.  
+* `on_host_maintenance` - What to do on host maintenance. Default is "MIGRATE".  
 * `service_accounts` or `scopes` - An array of OAuth2 account scopes for
   services that the instance will have access to. Those can be both full API
   scopes, just endpoint aliases (the part after `...auth/`), and `gcloud`
@@ -252,7 +252,9 @@ There is minimal support for synced folders. Upon `vagrant up`,
 `vagrant reload`, and `vagrant provision`, the Google provider will use
 `rsync` (if available) to uni-directionally sync the folder to the remote
 machine over SSH.
-See [Vagrant Synced folders: rsync](https://docs.vagrantup.com/v2/synced-folders/rsync.html)
+
+This is good enough for all built-in Vagrant provisioners (`shell`, `chef`, and
+`puppet`) to work!
 
 ## Development
 

--- a/lib/vagrant-google/action.rb
+++ b/lib/vagrant-google/action.rb
@@ -66,7 +66,7 @@ module VagrantPlugins
             end
 
             b2.use Provision
-            b2.use SyncedFolders
+            b2.use SyncFolders
           end
         end
       end
@@ -134,7 +134,7 @@ module VagrantPlugins
               b1.use Call, IsTerminated do |env2, b2|
                 if env2[:result]
                   b2.use Provision
-                  b2.use SyncedFolders
+                  b2.use SyncFolders
                   b2.use WarnNetworks
                   b2.use StartInstance
                 else
@@ -144,7 +144,7 @@ module VagrantPlugins
               end
             else
               b1.use Provision
-              b1.use SyncedFolders
+              b1.use SyncFolders
               b1.use WarnNetworks
               b1.use RunInstance
             end
@@ -182,6 +182,7 @@ module VagrantPlugins
       autoload :RunInstance, action_root.join("run_instance")
       autoload :StartInstance, action_root.join("start_instance")
       autoload :StopInstance, action_root.join("stop_instance")
+      autoload :SyncFolders, action_root.join("sync_folders")
       autoload :TerminateInstance, action_root.join("terminate_instance")
       autoload :TimedProvision, action_root.join("timed_provision")
       autoload :WarnNetworks, action_root.join("warn_networks")

--- a/lib/vagrant-google/action/sync_folders.rb
+++ b/lib/vagrant-google/action/sync_folders.rb
@@ -1,0 +1,104 @@
+# Copyright 2013 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require "log4r"
+require "vagrant/util/subprocess"
+require "vagrant/util/scoped_hash_override"
+require "vagrant/util/which"
+
+module VagrantPlugins
+  module Google
+    module Action
+      # This middleware uses `rsync` to sync the folders over to the
+      # Google instance.
+      class SyncFolders
+        include Vagrant::Util::ScopedHashOverride
+
+        def initialize(app, env)
+          @app    = app
+          @logger = Log4r::Logger.new("vagrant_google::action::sync_folders")
+        end
+
+        def call(env)
+          @app.call(env)
+
+          ssh_info = env[:machine].ssh_info
+
+          env[:machine].config.vm.synced_folders.each do |id, data|
+            data = scoped_hash_override(data, :google)
+
+            # Ignore disabled shared folders
+            next if data[:disabled]
+
+            unless Vagrant::Util::Which.which('rsync')
+              env[:ui].warn(I18n.t('vagrant_aws.rsync_not_found_warning'))
+              break
+            end
+
+            hostpath  = File.expand_path(data[:hostpath], env[:root_path])
+            guestpath = data[:guestpath]
+
+            # Make sure there is a trailing slash on the host path to
+            # avoid creating an additional directory with rsync
+            hostpath = "#{hostpath}/" if hostpath !~ /\/$/
+
+            # on windows rsync.exe requires cygdrive-style paths
+            if Vagrant::Util::Platform.windows?
+              hostpath = hostpath.gsub(/^(\w):/) { "/cygdrive/#{$1}" }
+            end
+
+            env[:ui].info(I18n.t("vagrant_google.rsync_folder",
+                                 :hostpath => hostpath,
+                                 :guestpath => guestpath))
+
+            # Create the guest path
+            env[:machine].communicate.sudo("mkdir -p '#{guestpath}'")
+            env[:machine].communicate.sudo(
+              "chown #{ssh_info[:username]} '#{guestpath}'")
+
+            # patch from https://github.com/tmatilai/vagrant-aws/commit/4a043a96076c332220ec4ec19470c4af5597dd51
+            def ssh_key_options(ssh_info)
+              # Ensure that `private_key_path` is an Array (for Vagrant < 1.4)
+              Array(ssh_info[:private_key_path]).map { |path| "-i '#{path}' " }.join
+            end
+
+            #collect rsync excludes specified :rsync__excludes=>['path1',...] in synced_folder options
+            excludes = ['.vagrant/', *Array(data[:rsync__excludes])]
+
+            # Rsync over to the guest path using the SSH info
+            command = [
+              "rsync", "--verbose", "--archive", "-z",
+              *excludes.map{|e| ['--exclude', e]}.flatten,
+              "-e", "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no #{ssh_key_options(ssh_info)}",
+              hostpath,
+              "#{ssh_info[:username]}@#{ssh_info[:host]}:#{guestpath}"]
+
+            # we need to fix permissions when using rsync.exe on windows, see
+            # http://stackoverflow.com/questions/5798807/rsync-permission-denied-created-directories-have-no-permissions
+            if Vagrant::Util::Platform.windows?
+              command.insert(1, "--chmod", "ugo=rwX")
+            end
+
+            r = Vagrant::Util::Subprocess.execute(*command)
+            if r.exit_code != 0
+              raise Errors::RsyncError,
+                    :guestpath => guestpath,
+                    :hostpath => hostpath,
+                    :stderr => r.stderr
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-google/version.rb
+++ b/lib/vagrant-google/version.rb
@@ -13,6 +13,6 @@
 # limitations under the License.
 module VagrantPlugins
   module Google
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/tasks/acceptance.rake
+++ b/tasks/acceptance.rake
@@ -44,7 +44,6 @@ namespace :acceptance do
       multi_instance
       preemptible
       scopes
-      synced_folder/rsync
       provisioner/shell
       provisioner/chef-solo
     ).map{ |s| "provider/google/#{s}" }


### PR DESCRIPTION
Temporarily reverting SyncedFolders action support due to a regression.
This will be released as 0.2.1 shortly.
See #94 for more details.

/CC @erjohnso 