### PR TITLE
Rewriting acceptance test tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,10 +298,10 @@ export GOOGLE_SSH_USER="testuser"
 export GOOGLE_SSH_KEY_LOCATION="/home/testuser/.ssh/id_rsa"
 ```
 
-After, you can run acceptance tests by running the `run` task in `acceptance`
+After, you can run acceptance tests by running the `full` task in `acceptance`
 namespace:
 ```sh
-$ bundle exec rake acceptance:run
+$ bundle exec rake acceptance:full
 ```
 
 **IMPORTANT NOTES**:

--- a/tasks/acceptance.rake
+++ b/tasks/acceptance.rake
@@ -14,14 +14,19 @@ end
 
 namespace :acceptance do
 
+  desc "Run full acceptance suite"
+  task :full => [:check_env, :run_full]
+
+  desc "Run smoke tests"
+  task :smoke => [:check_env, :run_smoke]
+
   desc "shows components that can be tested separately"
   task :components do
     exec("bundle exec vagrant-spec components")
   end
 
-  desc "runs acceptance tests using vagrant-spec"
-  task :run do
-
+  desc "checks if environment variables are set"
+  task :check_env do
     yellow "NOTE: For acceptance tests to be functional, correct ssh key needs to be added to GCE metadata."
 
     if !ENV["GOOGLE_JSON_KEY_LOCATION"] && !ENV["GOOGLE_KEY_LOCATION"]
@@ -39,7 +44,10 @@ namespace :acceptance do
     unless ENV["GOOGLE_SSH_USER"]
       puts "WARNING: GOOGLE_SSH_USER variable is not set. Will try to start tests using insecure Vagrant private key."
     end
+  end
 
+  desc "runs full set of acceptance tests using vagrant-spec"
+  task :run_full do
     components = %w(
       halt
       multi_instance
@@ -48,6 +56,18 @@ namespace :acceptance do
       scopes
       provisioner/shell
       provisioner/chef-solo
+    ).map{ |s| "provider/google/#{s}" }
+
+    command = "bundle exec vagrant-spec test --components=#{components.join(" ")}"
+    puts command
+    puts
+    exec(command)
+  end
+
+  desc "runs a basic shell provisioner test using vagrant-spec"
+  task :run_smoke do
+    components = %w(
+      provisioner/shell
     ).map{ |s| "provider/google/#{s}" }
 
     command = "bundle exec vagrant-spec test --components=#{components.join(" ")}"

--- a/test/acceptance/skeletons/generic/Vagrantfile
+++ b/test/acceptance/skeletons/generic/Vagrantfile
@@ -9,7 +9,6 @@ Vagrant.configure("2") do |config|
     google.zone = "europe-west1-d"
 
     google.zone_config "europe-west1-d" do |zone1d|
-      zone1d.name = "vagrant-testing-halt"
       zone1d.image = "debian-7-wheezy-v20150603"
       zone1d.zone = "europe-west1-d"
     end


### PR DESCRIPTION
- Separated the env checks from runner.
- Added smoke test task for basic sanity checking.
- Removed the 'name' parameter from the generic skeleton so
tests dependent on it can run in parallel.