### PR TITLE
Release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.2 (October 2015)
+
+* Cleanup instance and disks on backend failures [p0deje]
+* Refactoring ssh warnings into separate action [temikus]
+* Refactoring disk type detection logic [temikus]
+* Miscellaneous doc updates and minor fixes [mbrukman, temikus]
+
 # 0.2.1 (July 2015)
 
 * Temporarily reverted the old SyncedFolders behaviour. (See #94)

--- a/lib/vagrant-google/version.rb
+++ b/lib/vagrant-google/version.rb
@@ -13,6 +13,6 @@
 # limitations under the License.
 module VagrantPlugins
   module Google
-    VERSION = "0.2.1"
+    VERSION = "0.2.2"
   end
 end

--- a/tasks/acceptance.rake
+++ b/tasks/acceptance.rake
@@ -46,7 +46,6 @@ namespace :acceptance do
     end
   end
 
-  desc "runs full set of acceptance tests using vagrant-spec"
   task :run_full do
     components = %w(
       halt
@@ -64,7 +63,6 @@ namespace :acceptance do
     exec(command)
   end
 
-  desc "runs a basic shell provisioner test using vagrant-spec"
   task :run_smoke do
     components = %w(
       provisioner/shell


### PR DESCRIPTION
Releasing 0.2.2 gem :fireworks: 
/CC @erjohnso 
Can you please do the honours and set annotated tag with release notes:
`git tag -a 0.2.2`
```
* Cleanup instance and disks on backend failures [p0deje]
* Refactoring ssh warnings into separate action [temikus]
* Refactoring disk type detection logic [temikus]
* Miscellaneous doc updates and minor fixes [mbrukman, temikus]
```