### PR TITLE
Updating dependencies, release 2.2.3

### DIFF
--- a/lib/vagrant-google/version.rb
+++ b/lib/vagrant-google/version.rb
@@ -13,6 +13,6 @@
 # limitations under the License.
 module VagrantPlugins
   module Google
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end

--- a/vagrant-google.gemspec
+++ b/vagrant-google.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = "vagrant-google"
 
   s.add_runtime_dependency "fog-google", "~> 0.0.7"
+  s.add_runtime_dependency "google-api-client", "< 0.9", ">= 0.6.2"
 
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"


### PR DESCRIPTION
/CC @erjohnso - Emergency release to lock the google-api-client dep.
Please, tag it:
```
git tag -a 0.2.3
```
Release notes:
```
* Lock google-api-client dependency, since 0.9 is incompatible with fog.
```