### PR TITLE
Using private IP for SSH

### DIFF
--- a/lib/vagrant-google/action/read_ssh_info.rb
+++ b/lib/vagrant-google/action/read_ssh_info.rb
@@ -41,12 +41,25 @@ module VagrantPlugins
             machine.id = nil
             return nil
           end
+          # Check if we should use public or private IP address of the instance
+          # Get the zone we're going to use
+          zone = env[:machine].provider_config.zone
+          # Get the Bool value from the configs for that zone
+          use_private_ip = env[:machine].provider_config.get_zone_config(zone)zone_config.can_ip_forward
 
-          # Read SSH network info
-          return {
-            :host => server.public_ip_address,
-            :port => 22
-          }
+          if use_private_ip:
+            ssh_info = {
+              :host => server.private_ip_address,
+              :port => 22
+            }
+          else
+            ssh_info = {
+              :host => server.public_ip_address,
+              :port => 22
+            }
+          end
+          # Return SSH network info
+          return ssh_info
         end
       end
     end

--- a/lib/vagrant-google/action/read_ssh_info.rb
+++ b/lib/vagrant-google/action/read_ssh_info.rb
@@ -45,7 +45,7 @@ module VagrantPlugins
           # Get the zone we're going to use
           zone = env[:machine].provider_config.zone
           # Get the Bool value from the configs for that zone
-          use_private_ip = env[:machine].provider_config.get_zone_config(zone)zone_config.can_ip_forward
+          use_private_ip = env[:machine].provider_config.get_zone_config(zone)zone_config.use_private_ip
 
           if use_private_ip:
             ssh_info = {

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -82,6 +82,11 @@ module VagrantPlugins
       # @return [Array]
       attr_accessor :tags
 
+      # whether to use private IP for SSH
+      #
+      # @return Boolean
+      attr_accessor :use_private_ip
+
       # whether to enable ip forwarding
       #
       # @return Boolean
@@ -149,6 +154,7 @@ module VagrantPlugins
         @name                = UNSET_VALUE
         @network             = UNSET_VALUE
         @tags                = []
+        @use_private_ip      = UNSET_VALUE
         @can_ip_forward      = UNSET_VALUE
         @external_ip         = UNSET_VALUE
         @autodelete_disk     = UNSET_VALUE
@@ -264,6 +270,9 @@ module VagrantPlugins
 
         # autodelete_disk defaults to true
         @autodelete_disk = true if @autodelete_disk == UNSET_VALUE
+
+        # use_private_ip defaults to false
+        @use_private_ip = false if @use_private_ip == UNSET_VALUE
 
         # can_ip_forward defaults to nil
         @can_ip_forward = nil if @can_ip_forward == UNSET_VALUE


### PR DESCRIPTION
This adds the option to use the private IP for GCE Vagrant machines instead of the public one.

This is useful if you already have a VPN setup to your Vagrant GCE project and don't want to open your vagrant machines to the world.