### PR TITLE
SSH over private IP of the GCE instance

### DIFF
--- a/lib/vagrant-google/action/read_ssh_info.rb
+++ b/lib/vagrant-google/action/read_ssh_info.rb
@@ -41,12 +41,19 @@ module VagrantPlugins
             machine.id = nil
             return nil
           end
-
-          # Read SSH network info
-          return {
+          use_private_ip = zone.use_private_ip
+          ssh_info = {
             :host => server.public_ip_address,
             :port => 22
           }
+          if use_private_ip then
+            ssh_info = {
+              :host => server.private_ip_address,
+              :port => 22
+            }
+          end
+          # Return SSH network info
+          return ssh_info
         end
       end
     end

--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -52,6 +52,7 @@ module VagrantPlugins
           metadata            = zone_config.metadata
           tags                = zone_config.tags
           can_ip_forward      = zone_config.can_ip_forward
+          use_private_ip      = zone_config.use_private_ip
           external_ip         = zone_config.external_ip
           preemptible         = zone_config.preemptible
           auto_restart        = zone_config.auto_restart
@@ -72,6 +73,7 @@ module VagrantPlugins
           env[:ui].info(" -- Metadata:        '#{metadata}'")
           env[:ui].info(" -- Tags:            '#{tags}'")
           env[:ui].info(" -- IP Forward:      #{can_ip_forward}")
+          env[:ui].info(" -- Use private IP:  #{use_private_ip}")
           env[:ui].info(" -- External IP:     #{external_ip}")
           env[:ui].info(" -- Preemptible:     #{preemptible}")
           env[:ui].info(" -- Auto Restart:    #{auto_restart}")
@@ -125,6 +127,7 @@ module VagrantPlugins
               :metadata            => metadata,
               :tags                => tags,
               :can_ip_forward      => can_ip_forward,
+              :use_private_ip      => use_private_ip,
               :external_ip         => external_ip,
               :preemptible         => preemptible,
               :auto_restart        => auto_restart,


### PR DESCRIPTION
This adds a Boolean use_private_ip to the configurable options. Which allows to use the private IP to vagrant ssh.

Use case: you have a VPN to your GCE Vagrant project and don't want to give public SSH access to your machines.

Tested, working, default backwards compatible.
