### PR TITLE
Rake tests failed because of deprecated function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,11 @@ source "https://rubygems.org"
 
 gemspec
 
+# This is a restriction to avoid an error "undefined method 'last_comment'" which is deprecated
+# https://github.com/ruby/rake/issues/116
+# Remove it after update rspec-core-2.99.2 to version greater than 3.4.4
+gem 'rake', '< 11' 
+
 group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the

--- a/Gemfile
+++ b/Gemfile
@@ -16,17 +16,16 @@ source "https://rubygems.org"
 
 gemspec
 
-# This is a restriction to avoid an error "undefined method 'last_comment'" which is deprecated
-# https://github.com/ruby/rake/issues/116
-# Remove it after update rspec-core-2.99.2 to version greater or equal to 3.4.4
-gem 'rake', '< 11' 
-
 group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
   gem 'vagrant', git: "https://github.com/mitchellh/vagrant.git"
   gem 'vagrant-spec', git: "https://github.com/mitchellh/vagrant-spec.git"
+  # This is a restriction to avoid an error "undefined method 'last_comment'" which is deprecated
+  # https://github.com/ruby/rake/issues/116
+  # Remove it after update rspec-core-2.99.2 to version greater or equal to 3.4.4
+  gem 'rake', '< 11'
 end
 
 group :plugins do

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gemspec
 
 # This is a restriction to avoid an error "undefined method 'last_comment'" which is deprecated
 # https://github.com/ruby/rake/issues/116
-# Remove it after update rspec-core-2.99.2 to version greater than 3.4.4
+# Remove it after update rspec-core-2.99.2 to version greater or equal to 3.4.4
 gem 'rake', '< 11' 
 
 group :development do


### PR DESCRIPTION
Method `last_comment' is deprecated. 
```
lkuntar@lkuntar-VirtualBox:~/workspace/forks/vagrant-google$ bundle exec rake --trace
rake aborted!
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x00000003a090d0>
/var/lib/gems/2.2.0/gems/rspec-core-2.99.2/lib/rspec/core/rake_task.rb:143:in `initialize'
/home/lkuntar/workspace/forks/vagrant-google/tasks/test.rake:5:in `new'
/home/lkuntar/workspace/forks/vagrant-google/tasks/test.rake:5:in `block in <top (required)>'
/var/lib/gems/2.2.0/gems/rake-12.0.0/lib/rake/task_manager.rb:205:in `in_namespace'
/var/lib/gems/2.2.0/gems/rake-12.0.0/lib/rake/dsl_definition.rb:140:in `namespace'
/home/lkuntar/workspace/forks/vagrant-google/tasks/test.rake:4:in `<top (required)>'
/home/lkuntar/workspace/forks/vagrant-google/Rakefile:29:in `load'
/home/lkuntar/workspace/forks/vagrant-google/Rakefile:29:in `block in <top (required)>'
/home/lkuntar/workspace/forks/vagrant-google/Rakefile:28:in `each'
/home/lkuntar/workspace/forks/vagrant-google/Rakefile:28:in `<top (required)>'
/var/lib/gems/2.2.0/gems/rake-12.0.0/lib/rake/rake_module.rb:28:in `load'
/var/lib/gems/2.2.0/gems/rake-12.0.0/lib/rake/rake_module.rb:28:in `load_rakefile'
/var/lib/gems/2.2.0/gems/rake-12.0.0/lib/rake/application.rb:687:in `raw_load_rakefile'
/var/lib/gems/2.2.0/gems/rake-12.0.0/lib/rake/application.rb:96:in `block in load_rakefile'
/var/lib/gems/2.2.0/gems/rake-12.0.0/lib/rake/application.rb:178:in `standard_exception_handling'
/var/lib/gems/2.2.0/gems/rake-12.0.0/lib/rake/application.rb:95:in `load_rakefile'
/var/lib/gems/2.2.0/gems/rake-12.0.0/lib/rake/application.rb:79:in `block in run'
/var/lib/gems/2.2.0/gems/rake-12.0.0/lib/rake/application.rb:178:in `standard_exception_handling'
/var/lib/gems/2.2.0/gems/rake-12.0.0/lib/rake/application.rb:77:in `run'
/var/lib/gems/2.2.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/usr/local/bin/rake:23:in `load'
/usr/local/bin/rake:23:in `<main>'
```