### PR TITLE
Release 1.0

### DIFF
--- a/.ruby-version
+++ b/.ruby-version
@@ -1,2 +1,2 @@
-2.2.3
-# Tracking Vagrant 1.8.5
+2.3.0
+# Tracking Vagrant 1.9.7

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,10 @@
 
 source "https://rubygems.org"
 
-gemspec
+group :plugins do
+  # Dependencies need to be specified in vagrant-google.gemspec
+  gemspec
+end
 
 group :development do
   # We depend on Vagrant for development, but we don't add it as a
@@ -22,8 +25,4 @@ group :development do
   # Vagrant environment itself using `vagrant plugin`.
   gem 'vagrant', git: "https://github.com/mitchellh/vagrant.git"
   gem 'vagrant-spec', git: "https://github.com/mitchellh/vagrant-spec.git"
-end
-
-group :plugins do
-  gem "vagrant-google" , path: "."
 end

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a [Vagrant](http://www.vagrantup.com) 1.2+ plugin that adds an
 [Google Compute Engine](http://cloud.google.com/compute/) (GCE) provider to
 Vagrant, allowing Vagrant to control and provision instances in GCE.
 
-**NOTE:** This plugin requires Vagrant 1.2+.
+The maintainers for this plugin are @temikus(primary), @erjohnso(backup).
 
 ## Features
 
@@ -187,6 +187,7 @@ This provider exposes quite a few provider-specific configuration options:
   e.g. 10/08/2015 13:15:15 is "i-2015081013-15637fda".
 * `network` - The name of the network to use for the instance.  Default is
  "default".
+* `subnetwork` - The name of the subnetwork to use for the instance.
 * `tags` - An array of tags to apply to this instance.
 * `zone` - The zone name where the instance will be created.
 * `can_ip_forward` - Boolean whether to enable IP Forwarding.

--- a/lib/vagrant-google/version.rb
+++ b/lib/vagrant-google/version.rb
@@ -13,6 +13,6 @@
 # limitations under the License.
 module VagrantPlugins
   module Google
-    VERSION = "0.2.5".freeze
+    VERSION = "1.0.0".freeze
   end
 end

--- a/vagrant-google.gemspec
+++ b/vagrant-google.gemspec
@@ -33,7 +33,11 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"
-  s.add_development_dependency "rake"
+
+  # This is a restriction to avoid an error "undefined method 'last_comment'"
+  # which is deprecated (see https://github.com/ruby/rake/issues/116)
+  # Remove it after update rspec-core to version greater than or equal to 3.4.4
+  s.add_development_dependency "rake", "< 11.0"
   s.add_development_dependency "rspec", "~> 2.14"
   s.add_development_dependency "rubocop", "~> 0.35"
   s.add_development_dependency "highline"


### PR DESCRIPTION
About time we call it 1.0
Fixing #172, #171
Resolving #165 (can be closed)

@erjohnso - please, merge with release notes:
"Vagrant-google plugin can now be considered stable in its basic
functionality.

- Added subnetwork support [Wyosotis]
- Miscellaneous small bugfixes, doc and test updates [coryvirok,scanf,luto,Wyosotis,utdrmac,temikus]

Huge thanks to all contributors \o/"