### PR TITLE
Added GCE image family handling.

### DIFF
--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -43,6 +43,7 @@ module VagrantPlugins
           # Get the configs
           zone_config         = env[:machine].provider_config.get_zone_config(zone)
           image               = zone_config.image
+          image_family        = zone_config.image_family
           instance_group      = zone_config.instance_group
           name                = zone_config.name
           machine_type        = zone_config.machine_type
@@ -62,6 +63,11 @@ module VagrantPlugins
           autodelete_disk     = zone_config.autodelete_disk
           service_accounts    = zone_config.service_accounts
 
+          # If image_family is set, get the latest image image from the family.
+          if !image_family.nil?
+            image = env[:google_compute].images.get_from_family(image_family).name
+          end
+
           # Launch!
           env[:ui].info(I18n.t("vagrant_google.launching_instance"))
           env[:ui].info(" -- Name:            #{name}")
@@ -70,6 +76,7 @@ module VagrantPlugins
           env[:ui].info(" -- Disk size:       #{disk_size} GB")
           env[:ui].info(" -- Disk name:       #{disk_name}")
           env[:ui].info(" -- Image:           #{image}")
+          env[:ui].info(" -- Image family:    #{image_family}")
           env[:ui].info(" -- Instance Group:  #{instance_group}")
           env[:ui].info(" -- Zone:            #{zone}") if zone
           env[:ui].info(" -- Network:         #{network}") if network

--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -64,7 +64,7 @@ module VagrantPlugins
           service_accounts    = zone_config.service_accounts
 
           # If image_family is set, get the latest image image from the family.
-          if !image_family.nil?
+          unless image_family.nil?
             image = env[:google_compute].images.get_from_family(image_family).name
           end
 

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -42,6 +42,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :image
 
+      # The image family of the instance to use.
+      #
+      # @return [String]
+      attr_accessor :image_family
+
       # The instance group name to put the instance in.
       #
       # @return [String]
@@ -156,6 +161,7 @@ module VagrantPlugins
         @google_json_key_location = UNSET_VALUE
         @google_project_id   = UNSET_VALUE
         @image               = UNSET_VALUE
+        @image_family        = UNSET_VALUE
         @instance_group      = UNSET_VALUE
         @machine_type        = UNSET_VALUE
         @disk_size           = UNSET_VALUE
@@ -261,6 +267,9 @@ module VagrantPlugins
 
         # Image must be nil, since we can't default that
         @image = "debian-8-jessie-v20160511" if @image == UNSET_VALUE
+
+        # Default image family is nil
+        @image_family = nil if @image_family == UNSET_VALUE
 
         # Default instance group name is nil
         @instance_group = nil if @instance_group == UNSET_VALUE

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -266,7 +266,17 @@ module VagrantPlugins
         @google_project_id = ENV['GOOGLE_PROJECT_ID'] if @google_project_id == UNSET_VALUE
 
         # Image must be nil, since we can't default that
-        @image = "debian-8-jessie-v20160511" if @image == UNSET_VALUE
+        if (@image == UNSET_VALUE) && (@image_family == UNSET_VALUE)
+          @image = "debian-8-jessie-v20160511"
+        end
+
+        if @image == UNSET_VALUE
+          if @image_family == UNSET_VALUE
+            @image = "debian-8-jessie-v20160511"
+          else
+            @image = nil
+          end
+        end
 
         # Default image family is nil
         @image_family = nil if @image_family == UNSET_VALUE
@@ -382,9 +392,14 @@ module VagrantPlugins
             errors << I18n.t("vagrant_google.config.on_host_maintenance_invalid_on_preemptible") unless \
              config.on_host_maintenance == "TERMINATE"
           end
+
+          if config.image_family
+            errors << I18n.t("vagrant_google.config.image_and_image_family_set") if \
+             config.image
+          end
         end
 
-        errors << I18n.t("vagrant_google.config.image_required") if config.image.nil?
+        errors << I18n.t("vagrant_google.config.image_required") if config.image.nil? && config.image_family.nil?
         errors << I18n.t("vagrant_google.config.name_required") if @name.nil?
 
         { "Google Provider" => errors }

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -266,10 +266,6 @@ module VagrantPlugins
         @google_project_id = ENV['GOOGLE_PROJECT_ID'] if @google_project_id == UNSET_VALUE
 
         # Image must be nil, since we can't default that
-        if (@image == UNSET_VALUE) && (@image_family == UNSET_VALUE)
-          @image = "debian-8-jessie-v20160511"
-        end
-
         if @image == UNSET_VALUE
           if @image_family == UNSET_VALUE
             @image = "debian-8-jessie-v20160511"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -78,6 +78,8 @@ en:
       on_host_maintenance_invalid_on_preemptible: |-
         "on_host_maintenance" option must be set to "TERMINATE" for preemptible
         instances.
+      image_and_image_family_set: |-
+        "image" must be unset when setting "image_family"
 #-------------------------------------------------------------------------------
 # Translations for exception classes
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
I've added "image_family" as an available argument which overrides the image with the latest image from the family.  Tested on Linux with both private and public (centos-7) images.  I'm unable to run the acceptance tests as I keep getting:
 `stderr: /usr/lib/ruby/vendor_ruby/bundler/source/git.rb:191:in 'rescue in load_spec_files': https://github.com/mitchellh/vagrant-spec.git (at master@e623a56) is not yet checked out. Run `bundle install` first. (Bundler::GitError)` even though `bundle install` was run (I'm not really a ruby programmer). 