### PR TITLE
Add support for creating instances on shared VPC networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ will pull the most recent CentOS 7 image. For more info, refer to
   e.g. 10/08/2015 13:15:15 is "i-2015081013-15637fda".
 * `network` - The name of the network to use for the instance.  Default is
  "default".
+* `network_project_id` - The ID of the GCP project for the network and subnetwork to use for the instance. Default is `google_project_id`.
 * `subnetwork` - The name of the subnetwork to use for the instance.
 * `tags` - An array of tags to apply to this instance.
 * `labels` - Custom key/value pairs of labels to add to the instance.

--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -51,6 +51,7 @@ module VagrantPlugins
           disk_name           = zone_config.disk_name
           disk_type           = zone_config.disk_type
           network             = zone_config.network
+          network_project_id  = zone_config.network_project_id
           subnetwork          = zone_config.subnetwork
           metadata            = zone_config.metadata
           labels              = zone_config.labels
@@ -78,6 +79,7 @@ module VagrantPlugins
           env[:ui].info(" -- Instance Group:  #{instance_group}")
           env[:ui].info(" -- Zone:            #{zone}") if zone
           env[:ui].info(" -- Network:         #{network}") if network
+          env[:ui].info(" -- Network Project: #{network_project_id}") if network_project_id
           env[:ui].info(" -- Subnetwork:      #{subnetwork}") if subnetwork
           env[:ui].info(" -- Metadata:        '#{metadata}'")
           env[:ui].info(" -- Labels:          '#{labels}'")
@@ -101,8 +103,8 @@ module VagrantPlugins
 
           # Munge network configs
           if network != 'default'
-            network = "projects/#{project_id}/global/networks/#{network}"
-            subnetwork  = "projects/#{project_id}/regions/#{zone.split('-')[0..1].join('-')}/subnetworks/#{subnetwork}"
+            network = "projects/#{network_project_id}/global/networks/#{network}"
+            subnetwork  = "projects/#{network_project_id}/regions/#{zone.split('-')[0..1].join('-')}/subnetworks/#{subnetwork}"
           else
             network = "global/networks/default"
           end

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -82,6 +82,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :network
 
+      # The name of the network_project_id
+      #
+      # @return [String]
+      attr_accessor :network_project_id
+
       # The name of the subnetwork
       #
       # @return [String]
@@ -169,6 +174,7 @@ module VagrantPlugins
         @metadata            = {}
         @name                = UNSET_VALUE
         @network             = UNSET_VALUE
+        @network_project_id  = UNSET_VALUE
         @subnetwork          = UNSET_VALUE
         @tags                = []
         @labels              = {}
@@ -288,6 +294,9 @@ module VagrantPlugins
         end
         # Network defaults to 'default'
         @network = "default" if @network == UNSET_VALUE
+
+        # Network project id defaults to project_id
+        @network_project_id = @google_project_id if @network_project_id == UNSET_VALUE
 
         # Subnetwork defaults to nil
         @subnetwork = nil if @subnetwork == UNSET_VALUE

--- a/test/unit/common/config_test.rb
+++ b/test/unit/common/config_test.rb
@@ -55,7 +55,7 @@ describe VagrantPlugins::Google::Config do
     # each of these attributes to "foo" in isolation, and reads the value
     # and asserts the proper result comes back out.
     [:name, :image, :zone, :instance_ready_timeout, :machine_type, :disk_size, :disk_name, :disk_type,
-     :network, :metadata, :labels, :can_ip_forward, :external_ip, :autodelete_disk].each do |attribute|
+     :network, :network_project_id, :metadata, :labels, :can_ip_forward, :external_ip, :autodelete_disk].each do |attribute|
 
       it "should not default #{attribute} if overridden" do
         instance.send("#{attribute}=".to_sym, "foo")


### PR DESCRIPTION
@Temikus and @erjohnso I tested this and it is working in my environment. I tested the below three scenarios.

1. Using the `default` network
2. Using a custom network(not the default one)
3. Using an XPN network from a different GCP project(shared VPC)

I still need to update the unit tests for this new config option. I should be able to update these in the next day or two.