### PR TITLE
Add config option for image project id

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ This provider exposes quite a few provider-specific configuration options:
 * `image_family` - Specify an "image family" to pull the latest image from. For example: `centos-7` 
 will pull the most recent CentOS 7 image. For more info, refer to 
 [Google Image documentation](https://cloud.google.com/compute/docs/images#image_families).
+* `image_project_id` - The ID of the GCP project to search for the `image` or `image_family`.
 * `instance_group` - Unmanaged instance group to add the machine to. If one
   doesn't exist it will be created.
 * `instance_ready_timeout` - The number of seconds to wait for the instance

--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -44,6 +44,7 @@ module VagrantPlugins
           zone_config         = env[:machine].provider_config.get_zone_config(zone)
           image               = zone_config.image
           image_family        = zone_config.image_family
+          image_project_id    = zone_config.image_project_id
           instance_group      = zone_config.instance_group
           name                = zone_config.name
           machine_type        = zone_config.machine_type
@@ -76,6 +77,7 @@ module VagrantPlugins
           env[:ui].info(" -- Disk name:       #{disk_name}")
           env[:ui].info(" -- Image:           #{image}")
           env[:ui].info(" -- Image family:    #{image_family}")
+          env[:ui].info(" -- Image Project:   #{image_project_id}") if image_project_id
           env[:ui].info(" -- Instance Group:  #{instance_group}")
           env[:ui].info(" -- Zone:            #{zone}") if zone
           env[:ui].info(" -- Network:         #{network}") if network
@@ -94,11 +96,11 @@ module VagrantPlugins
           env[:ui].info(" -- Scopes:          #{service_accounts}")
 
           # Munge image configs
-          image = env[:google_compute].images.get(image).self_link
+          image = env[:google_compute].images.get(image, image_project_id).self_link
 
           # If image_family is set, get the latest image image from the family.
           unless image_family.nil?
-            image = env[:google_compute].images.get_from_family(image_family).self_link
+            image = env[:google_compute].images.get_from_family(image_family, image_project_id).self_link
           end
 
           # Munge network configs

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -42,6 +42,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :image_family
 
+      # The name of the image_project_id
+      #
+      # @return [String]
+      attr_accessor :image_project_id
+
       # The instance group name to put the instance in.
       #
       # @return [String]
@@ -166,6 +171,7 @@ module VagrantPlugins
         @google_project_id   = UNSET_VALUE
         @image               = UNSET_VALUE
         @image_family        = UNSET_VALUE
+        @image_project_id    = UNSET_VALUE
         @instance_group      = UNSET_VALUE
         @machine_type        = UNSET_VALUE
         @disk_size           = UNSET_VALUE
@@ -270,6 +276,9 @@ module VagrantPlugins
 
         # Default image family is nil
         @image_family = nil if @image_family == UNSET_VALUE
+
+        # Default image project is nil
+        @image_project_id = nil if @image_project_id == UNSET_VALUE
 
         # Default instance group name is nil
         @instance_group = nil if @instance_group == UNSET_VALUE

--- a/test/unit/common/config_test.rb
+++ b/test/unit/common/config_test.rb
@@ -32,6 +32,8 @@ describe VagrantPlugins::Google::Config do
 
     its("name")                   { should match "i-[0-9]{10}-[0-9a-f]{4}" }
     its("image")                  { should be_nil }
+    its("image_family")           { should be_nil }
+    its("image_project_id")       { should be_nil }
     its("instance_group")         { should be_nil }
     its("zone")                   { should == "us-central1-f" }
     its("network")                { should == "default" }
@@ -54,7 +56,7 @@ describe VagrantPlugins::Google::Config do
     # simple boilerplate test, so I cut corners here. It just sets
     # each of these attributes to "foo" in isolation, and reads the value
     # and asserts the proper result comes back out.
-    [:name, :image, :zone, :instance_ready_timeout, :machine_type, :disk_size, :disk_name, :disk_type,
+    [:name, :image, :image_family, :image_project_id, :zone, :instance_ready_timeout, :machine_type, :disk_size, :disk_name, :disk_type,
      :network, :network_project_id, :metadata, :labels, :can_ip_forward, :external_ip, :autodelete_disk].each do |attribute|
 
       it "should not default #{attribute} if overridden" do


### PR DESCRIPTION
The new config option image_project_id allows specifying which GCP project the image or image_family resides in. Allows using a custom GCE image that is in a different project than the project that the GCE instance will be created in.

Fixes #161