### PR TITLE
WIP: add support for setting IAM service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ will pull the most recent CentOS 7 image. For more info, refer to
   scopes, just endpoint aliases (the part after `...auth/`), and `gcloud`
   utility aliases, for example:
   `['storage-full', 'bigquery', 'https://www.googleapis.com/auth/compute']`.
+* `service_account` - The IAM service account email to use for the instance.
 
 These can be set like typical provider-specific configuration:
 

--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -65,6 +65,7 @@ module VagrantPlugins
           on_host_maintenance = zone_config.on_host_maintenance
           autodelete_disk     = zone_config.autodelete_disk
           service_accounts    = zone_config.service_accounts
+          service_account     = zone_config.service_account
           project_id          = zone_config.google_project_id
 
           # Launch!
@@ -93,7 +94,8 @@ module VagrantPlugins
           env[:ui].info(" -- Auto Restart:    #{auto_restart}")
           env[:ui].info(" -- On Maintenance:  #{on_host_maintenance}")
           env[:ui].info(" -- Autodelete Disk: #{autodelete_disk}")
-          env[:ui].info(" -- Scopes:          #{service_accounts}")
+          env[:ui].info(" -- Scopes:          #{service_accounts}") if service_accounts
+          env[:ui].info(" -- Service Account: #{service_account}") if service_account
 
           # Munge image configs
           image = env[:google_compute].images.get(image, image_project_id).self_link
@@ -122,7 +124,7 @@ module VagrantPlugins
           scheduling = { :automatic_restart => auto_restart, :on_host_maintenance => on_host_maintenance, :preemptible => preemptible}
 
           # Munge service_accounts / scopes config
-          service_accounts = [ { :scopes => service_accounts } ]
+          service_accounts = [ { :email => service_account, :scopes => service_accounts } ]
 
           begin
             request_start_time = Time.now.to_i

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -158,12 +158,17 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :zone
 
-      # The list of access controls for service accounts.
+      # The list of access scopes for instance.
       #
       # @return [Array]
       attr_accessor :service_accounts
       alias scopes service_accounts
       alias scopes= service_accounts=
+
+      # IAM service account for instance.
+      #
+      # @return [String]
+      attr_accessor :service_account
 
       def initialize(zone_specific=false)
         @google_client_email = UNSET_VALUE
@@ -194,6 +199,7 @@ module VagrantPlugins
         @instance_ready_timeout = UNSET_VALUE
         @zone                = UNSET_VALUE
         @service_accounts    = UNSET_VALUE
+        @service_account     = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -337,8 +343,11 @@ module VagrantPlugins
         # Default instance_ready_timeout
         @instance_ready_timeout = 20 if @instance_ready_timeout == UNSET_VALUE
 
-        # Default service_accounts
+        # Default access scopes
         @service_accounts = nil if @service_accounts == UNSET_VALUE
+
+        # Default IAM service account
+        @service_account = nil if @service_account == UNSET_VALUE
 
         # Compile our zone specific configurations only within
         # NON-zone-SPECIFIC configurations.


### PR DESCRIPTION
This PR adds a new config option `service_account` for setting the GCP IAM service account on the GCE instance. I tested it and everything seems to be working. No conflict with the exiting config options `service_accounts` and `scopes`. It implements the feature  enhancement requested in #185.

I need some feed back on the below idea ...

I think it is going to be confusing to have a `service_accounts` and `service_account` config option. I think what would make most sense would be to get rid of the `service_accounts` config option. We would end up with a `scopes` option for setting the API scopes and a `service_account` option for setting the email address of the IAM service account. This would be a breaking change, so the next version would need to be 3.0.0.

Or maybe instead or `service_account` we should use `service_account_email`. Either way my opinion is that we should get rid of the `service_accounts` config option.

@Temikus, @erjohnso, and @zackangelo what do you think about this?