### PR TITLE
Bump fog-google to 1.4 & release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,22 @@
-# 2.1.0 (May 2018)
+# Changelog
+All notable changes to this project will be documented in this file.
+The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## 2.2.0 (June 2018)
+
+#### Fixed
+* Bumped fog-google to v1.4.
+This is a necessary upstream update to work properly with Ruby 2.4+ on some
+platforms.
+
+## 2.1.0 (May 2018)
 
 * Add new configuration option `image_project_id` to allow using GCE images from other projects. [seanmalloy]
 * Add new configuration option `network_project_id` to allow using GCP Shared VPC networks. [seanmalloy]
 * Add new configuration option `service_account` to allow setting the IAM service account on instances. [seanmalloy]
 * Deprecate configuration option `service_accounts`. Use `scopes` configuration option instead. [seanmalloy]
 
-# 2.0.0 (March 2018)
+## 2.0.0 (March 2018)
 
 * Update to use fog-google gem v1
 * Add new configuration option `labels` for setting [labels](https://cloud.google.com/compute/docs/labeling-resources) 
@@ -18,23 +29,23 @@
     specified at runtime
   * Rsync behavior now consistent with Vagrant's default, removed old rsync code
 
-# 1.0.0 (July 2017)
-# 0.2.5 (October 2016)
-# 0.2.4 (April 2016)
-# 0.2.3 (January 2016)
+## 1.0.0 (July 2017)
+## 0.2.5 (October 2016)
+## 0.2.4 (April 2016)
+## 0.2.3 (January 2016)
 
-# 0.2.2 (October 2015)
+## 0.2.2 (October 2015)
 
 * Cleanup instance and disks on backend failures [p0deje]
 * Refactoring ssh warnings into separate action [temikus]
 * Refactoring disk type detection logic [temikus]
 * Miscellaneous doc updates and minor fixes [mbrukman, temikus]
 
-# 0.2.1 (July 2015)
+## 0.2.1 (July 2015)
 
 * Temporarily reverted the old SyncedFolders behaviour. (See #94)
 
-# 0.2.0 (July 2015)
+## 0.2.0 (July 2015)
 
 * Added support for service account definitions [tcr]
 * Added support for preemptible instances [jcdang]
@@ -48,7 +59,7 @@
 * Updated documentation and examples [mbrukman, temikus]
 * Miscellaneous UI/UX updates and bugfixes [temikus]
 
-# 0.1.5 (May 2015)
+## 0.1.5 (May 2015)
 
 * Added support for JSON private keys [temikus]
 * Added disk_type parameter support [temikus]
@@ -57,23 +68,23 @@
 * Added support for user specified rsync excludes [patkar]
 * Miscellaneous bugfixes [mbrukman, beauzeaux, iceydee, mklbtz, temikus]
 
-# 0.1.4 (October 2014)
+## 0.1.4 (October 2014)
 
 * Add option for disk size [franzs]
 * Add tags [ptone]
 * Updated default for latest Debian image
 
-# 0.1.3 (July 2014)
+## 0.1.3 (July 2014)
 
 * Updated all image references
 * Fixed fog deprecation warning
 * Updated example box `google.box`
 * Got spec tests passing again
 
-# 0.1.1 (October 11, 2013)
+## 0.1.1 (October 11, 2013)
 
 * Fixed bug with instance ready/SSH
 
-# 0.1.0 (August 14, 2013)
+## 0.1.0 (August 14, 2013)
 
 * Initial release.

--- a/lib/vagrant-google/version.rb
+++ b/lib/vagrant-google/version.rb
@@ -13,6 +13,6 @@
 # limitations under the License.
 module VagrantPlugins
   module Google
-    VERSION = "2.1.0".freeze
+    VERSION = "2.2.0".freeze
   end
 end

--- a/vagrant-google.gemspec
+++ b/vagrant-google.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-google"
 
-  s.add_runtime_dependency "fog-google", "~> 1.3"
+  s.add_runtime_dependency "fog-google", "~> 1.4"
 
   # This is a restriction to avoid errors on `failure_message_for_should`
   # TODO: revise after vagrant_spec goes past >0.0.1 (at master@e623a56)


### PR DESCRIPTION
Necessary upstream update to work properly with Ruby 2.4+ on some
platforms.

Fixes #201