### PR TITLE
Deprecate Debian 8 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Vagrant.configure("2") do |config|
 
     google.zone_config "us-central1-f" do |zone1f|
         zone1f.name = "testing-vagrant"
-        zone1f.image = "debian-8-jessie-v20180307"
+        zone1f.image = "debian-9-stretch-v20180611"
         zone1f.machine_type = "n1-standard-4"
         zone1f.zone = "us-central1-f"
         zone1f.metadata = {'custom' => 'metadata', 'testing' => 'foobarbaz'}

--- a/vagrantfile_examples/Vagrantfile.multiple_machines
+++ b/vagrantfile_examples/Vagrantfile.multiple_machines
@@ -63,7 +63,7 @@ Vagrant.configure("2") do |config|
 
       google.zone_config "us-central1-c" do |z1c_zone|
         z1c_zone.name = "z1c"
-        z1c_zone.image = "debian-8-jessie-v20160923"
+        z1c_zone.image = "debian-9-stretch-v20180611"
         z1c_zone.machine_type = "n1-standard-1"
         z1c_zone.zone = "us-central1-c"
         z1c_zone.metadata = {"zone" => "US Central 1c"}
@@ -83,7 +83,7 @@ Vagrant.configure("2") do |config|
 
       google.zone_config "us-central1-f" do |z1f_zone|
         z1f_zone.name = "z1f"
-        z1f_zone.image = "debian-8-jessie-v20160923"
+        z1f_zone.image = "debian-9-stretch-v20180611"
         z1f_zone.machine_type = "n1-standard-2"
         z1f_zone.zone = "us-central1-f"
         z1f_zone.metadata = {"zone" => "US Central 1f"}

--- a/vagrantfile_examples/Vagrantfile.provision_single
+++ b/vagrantfile_examples/Vagrantfile.provision_single
@@ -36,7 +36,7 @@ Vagrant.configure("2") do |config|
 
     # Override provider defaults
     google.name = "testing-vagrant"
-    google.image = "debian-8-jessie-v20160923"
+    google.image = "debian-9-stretch-v20180611"
     google.machine_type = "n1-standard-1"
     google.zone = "us-central1-f"
     google.metadata = {'custom' => 'metadata', 'testing' => 'foobarbaz'}

--- a/vagrantfile_examples/Vagrantfile.zone_config
+++ b/vagrantfile_examples/Vagrantfile.zone_config
@@ -30,7 +30,7 @@ Vagrant.configure("2") do |config|
 
     google.zone_config "us-central1-f" do |zone1a|
         zone1a.name = "testing-vagrant"
-        zone1a.image = "debian-8-jessie-v20160923"
+        zone1a.image = "debian-9-stretch-v20180611"
         zone1a.machine_type = "n1-standard-4"
         zone1a.zone = "us-central1-f"
         zone1a.scopes = ['bigquery', 'monitoring', 'https://www.googleapis.com/auth/compute']


### PR DESCRIPTION
Debian 8 has reached its end-of-life as of 18th June 2018
at which point it is in the Long-Term Support stage of the
Debian lifecycle (which is best effort). Debian 9 “Stretch”
is the current stable release of Debian.