### PR TITLE
Allow adding additional disks to GCE instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,18 +210,20 @@ will pull the most recent CentOS 7 image. For more info, refer to
   utility aliases, for example:
   `['storage-full', 'bigquery', 'https://www.googleapis.com/auth/compute']`.
 * `service_account` - The IAM service account email to use for the instance.
-* `additional_disks` - An array of additional disk configurations. Here is an exmaple of configuration.
-* [{
-*   :image_family => "google-image-family",
-*   :image => nil,
-*   :image_project_id => "google-project-id",
-*   :disk_size => 20,
-*   :disk_name => "google-additional-disk-0",
-*   :disk_type => "pd-standard",
-*   :autodelete_disk => true
-*  }]
-* For additional disks, `disk_size` is default to `10`GB; `disk_name` is default to `name` + "-additional-disk-#{index}"; 
-  `disk_type` is default to `pd-standard`; `autodelete_disk` is default to `true`.
+* `additional_disks` - An array of additional disk configurations. `disk_size` is default to `10`GB; 
+  `disk_name` is default to `name` + "-additional-disk-#{index}"; `disk_type` is default to `pd-standard`; 
+  `autodelete_disk` is default to `true`. Here is an example of configuration.
+```ruby
+  [{
+   :image_family => "google-image-family",
+   :image => nil,
+   :image_project_id => "google-project-id",
+   :disk_size => 20,
+   :disk_name => "google-additional-disk-0",
+   :disk_type => "pd-standard",
+   :autodelete_disk => true
+  }]
+```
 
 These can be set like typical provider-specific configuration:
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,18 @@ will pull the most recent CentOS 7 image. For more info, refer to
   utility aliases, for example:
   `['storage-full', 'bigquery', 'https://www.googleapis.com/auth/compute']`.
 * `service_account` - The IAM service account email to use for the instance.
+* `additional_disks` - An array of additional disk configurations. Here is an exmaple of configuration.
+* [{
+*   :image_family => "google-image-family",
+*   :image => nil,
+*   :image_project_id => "google-project-id",
+*   :disk_size => 20,
+*   :disk_name => "google-additional-disk-0",
+*   :disk_type => "pd-standard",
+*   :autodelete_disk => true
+*  }]
+* For additional disks, `disk_size` is default to `10`GB; `disk_name` is default to `name` + "-additional-disk-#{index}"; 
+  `disk_type` is default to `pd-standard`; `autodelete_disk` is default to `true`.
 
 These can be set like typical provider-specific configuration:
 

--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -97,7 +97,7 @@ module VagrantPlugins
           env[:ui].info(" -- Autodelete Disk: #{autodelete_disk}")
           env[:ui].info(" -- Scopes:          #{service_account_scopes}") if service_account_scopes
           env[:ui].info(" -- Service Account: #{service_account}") if service_account
-          env[:ui].info(" -- additional Disks:#{additional_disks}")
+          env[:ui].info(" -- Additional Disks:#{additional_disks}")
 
           # Munge image config
           if image_family
@@ -129,7 +129,7 @@ module VagrantPlugins
 
           begin
             request_start_time = Time.now.to_i
-
+            disk = nil
             # Check if specified external ip is available
             external_ip = get_external_ip(env, external_ip) if external_ip
             # Check if disk type is available in the zone and set the proper resource link
@@ -164,7 +164,7 @@ module VagrantPlugins
             end
 
             # Add boot disk to the instance
-            disks = [disk.get_as_boot_disk(boo:true, auto_delete:autodelete_disk)]
+            disks = [disk.get_as_boot_disk(true, autodelete_disk)]
 
             # Configure additional disks
             additional_disks.each_with_index do |disk_config, index|
@@ -264,7 +264,9 @@ module VagrantPlugins
             # TODO: Cleanup the Fog catch-all once Fog implements better exceptions
             # There is a chance Google has failed to create an instance, so we need
             # to clean up the created disk.
-            cleanup_disk(disk.name, env) if disk && disk_created_by_vagrant
+            disks.each do |disk|
+                cleanup_disk(disk.name, env) if disk && disk_created_by_vagrant
+            end
             raise Errors::FogError, :message => e.message
           end
 

--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -67,6 +67,7 @@ module VagrantPlugins
           service_account_scopes = zone_config.scopes
           service_account        = zone_config.service_account
           project_id             = zone_config.google_project_id
+          additional_disks       = zone_config.additional_disks
 
           # Launch!
           env[:ui].info(I18n.t("vagrant_google.launching_instance"))
@@ -96,6 +97,7 @@ module VagrantPlugins
           env[:ui].info(" -- Autodelete Disk: #{autodelete_disk}")
           env[:ui].info(" -- Scopes:          #{service_account_scopes}") if service_account_scopes
           env[:ui].info(" -- Service Account: #{service_account}") if service_account
+          env[:ui].info(" -- additional Disks:#{additional_disks}")
 
           # Munge image config
           if image_family
@@ -161,6 +163,83 @@ module VagrantPlugins
               end
             end
 
+            # Add boot disk to the instance
+            disks = [disk.get_as_boot_disk(boo:true, auto_delete:autodelete_disk)]
+
+            # Configure additional disks
+            additional_disks.each_with_index do |disk_config, index|
+              additional_disk = nil
+
+              # Get additional disk image
+              # Create a blank disk if neither image nor additional_disk_image is provided
+              additional_disk_image = nil
+              if disk_config[:image_family]
+                additional_disk_image = env[:google_compute].images.get_from_family(disk_config[:image_family], disk_config[:image_project_id]).self_link
+              elsif disk_config[:image]
+                additional_disk_image = env[:google_compute].images.get(disk_config[:image], disk_config[:image_project_id]).self_link
+              end
+
+              # Get additional disk size
+              additional_disk_size = nil
+              if disk_config[:disk_size].nil?
+                # Default disk size is 10 GB
+                additional_disk_size = 10
+              else
+                additional_disk_size = disk_config[:disk_size]
+              end
+
+              # Get additional disk type
+              additional_disk_type = nil
+              if disk_config[:disk_type].nil?
+                # Default disk type is pd-standard
+                additional_disk_type = get_disk_type(env, "pd-standard", zone)
+              else
+                additional_disk_type = get_disk_type(env, disk_config[:disk_type], zone)
+              end
+
+              # Get additional disk auto delete
+              additional_disk_auto_delete = nil
+              if disk_config[:disk_type].nil?
+                # Default auto delete to true
+                additional_disk_auto_delete = true
+              else
+                additional_disk_auto_delete = disk_config[:autodelete_disk]
+              end
+
+              # Get additional disk name
+              additional_disk_name = nil
+              if disk_config[:disk_name].nil?
+                # no disk_name... disk_name defaults to instance (name + "-additional-disk-#{index}"
+                additional_disk_name = name + "-additional-disk-#{index}"
+                additional_disk = env[:google_compute].disks.create(
+                  name: additional_disk_name,
+                  size_gb: additional_disk_size,
+                  type: additional_disk_type,
+                  zone_name: zone,
+                  source_image: additional_disk_image
+                )
+              else
+                # additional_disk_name set in disk_config
+                additional_disk_name = disk_config[:disk_name]
+
+                additional_disk = env[:google_compute].disks.get(additional_disk_name, zone)
+                if additional_disk.nil?
+                  # disk not found... create it with name
+                  additional_disk = env[:google_compute].disks.create(
+                    name: additional_disk_name,
+                    size_gb: additional_disk_size,
+                    type: additional_disk_type,
+                    zone_name: zone,
+                    source_image: additional_disk_image
+                  )
+                  additional_disk.wait_for { additional_disk.ready? }
+                end
+              end
+
+              # Add additional disk to the instance
+              disks.push(additional_disk.attached_disk_obj(boot:false, writable:true, auto_delete:additional_disk_auto_delete))
+            end
+
             defaults = {
               :name                => name,
               :zone                => zone,
@@ -175,7 +254,7 @@ module VagrantPlugins
               :can_ip_forward      => can_ip_forward,
               :use_private_ip      => use_private_ip,
               :external_ip         => external_ip,
-              :disks               => [disk.get_as_boot_disk(true, autodelete_disk)],
+              :disks               => disks,
               :scheduling          => scheduling,
               :service_accounts    => service_accounts
             }

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -173,6 +173,11 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :service_account
 
+      # The configuration for additional disks.
+      #
+      # @return [Array<Hash>]
+      attr_accessor :additional_disks
+
       def initialize(zone_specific=false)
         @google_client_email = UNSET_VALUE
         @google_json_key_location = UNSET_VALUE
@@ -204,6 +209,7 @@ module VagrantPlugins
         @scopes              = UNSET_VALUE
         @service_accounts    = UNSET_VALUE
         @service_account     = UNSET_VALUE
+        @additional_disks    = []
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)

--- a/test/unit/common/config_test.rb
+++ b/test/unit/common/config_test.rb
@@ -46,6 +46,7 @@ describe VagrantPlugins::Google::Config do
     its("tags")                   { should == [] }
     its("labels")                 { should == {} }
     its("scopes")                 { should == nil }
+    its("additional_disks").      { should == [] }
     its("preemptible")            { should be_falsey }
     its("auto_restart")           { should }
     its("on_host_maintenance")    { should == "MIGRATE" }


### PR DESCRIPTION
Created `additional_disks` option that attach additional disks to GCE instance.
https://github.com/fog/fog-google/pull/434