### PR TITLE
feat: Allow without explicit service account

### DIFF
--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -403,13 +403,12 @@ module VagrantPlugins
           # TODO: Check why provider-level settings are validated in the zone config
           errors << I18n.t("vagrant_google.config.google_project_id_required") if \
             config.google_project_id.nil?
-          errors << I18n.t("vagrant_google.config.google_client_email_required") if \
-            config.google_client_email.nil?
-          errors << I18n.t("vagrant_google.config.google_key_location_required") if \
-            config.google_json_key_location.nil?
-          errors << I18n.t("vagrant_google.config.private_key_missing") unless \
-            File.exist?(File.expand_path(config.google_json_key_location.to_s)) or
-            File.exist?(File.expand_path(config.google_json_key_location.to_s, machine.env.root_path))
+
+          if config.google_json_key_location
+            errors << I18n.t("vagrant_google.config.private_key_missing") unless \
+              File.exist?(File.expand_path(config.google_json_key_location.to_s)) or
+              File.exist?(File.expand_path(config.google_json_key_location.to_s, machine.env.root_path))
+          end
 
           if config.preemptible
             errors << I18n.t("vagrant_google.config.auto_restart_invalid_on_preemptible") if \

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -52,9 +52,6 @@ en:
 # Translations for config validation errors
 #-------------------------------------------------------------------------------
     config:
-      google_client_email_required: |-
-        A Google Service Account client email is required via
-        "google_client_email".
       private_key_missing: |-
         Private key for Google could not be found in the specified location.
       zone_required: |-
@@ -63,9 +60,6 @@ en:
         An instance name must be specified via "name" option.
       image_required: |-
         An image must be specified via "image" or "image_family" option.
-      google_key_location_required: |-
-        A private key pathname is required via:
-         "google_json_key_location" (for JSON keys)
       google_project_id_required: |-
         A Google Cloud Project ID is required via "google_project_id".
       auto_restart_invalid_on_preemptible: |-

--- a/test/unit/common/config_test.rb
+++ b/test/unit/common/config_test.rb
@@ -111,17 +111,6 @@ describe VagrantPlugins::Google::Config do
       its("google_client_email") { should == "client_id_email" }
       its("google_json_key_location") { should == "/path/to/json/key" }
     end
-
-    context "With none of the Google credential environment variables set" do
-      before :each do
-        allow(ENV).to receive(:[]).with("GOOGLE_CLIENT_EMAIL").and_return("client_id_email")
-      end
-
-      it "Should return no key set errors" do
-        instance.finalize!
-        expect(instance.validate("foo")["Google Provider"][1]).to include("en.vagrant_google.config.google_key_location_required")
-      end
-    end
   end
 
   describe "zone config" do

--- a/vagrant-google.gemspec
+++ b/vagrant-google.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-google"
 
-  s.add_runtime_dependency "fog-google", "~> 1.8.1"
+  s.add_runtime_dependency "fog-google", "~> 1.9.0"
 
   # This is a restriction to avoid errors on `failure_message_for_should`
   # TODO: revise after vagrant_spec goes past >0.0.1 (at master@e623a56)

--- a/vagrant-google.gemspec
+++ b/vagrant-google.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-google"
 
-  s.add_runtime_dependency "fog-google", "~> 1.9.0"
+  s.add_runtime_dependency "fog-google", "~> 1.9.1"
 
   # This is a restriction to avoid errors on `failure_message_for_should`
   # TODO: revise after vagrant_spec goes past >0.0.1 (at master@e623a56)


### PR DESCRIPTION
With the update to `fog-google` that allows more authentication flows,
we can remove the requirements for explicit service account credentials.

Closes #194