### PR TITLE
fix: Set a default zone only if `default` network is used

### DIFF
--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -152,8 +152,8 @@ module VagrantPlugins
       # @return [Int]
       attr_accessor :instance_ready_timeout
 
-      # The zone to launch the instance into. If nil, it will
-      # use the default us-central1-f.
+      # The zone to launch the instance into.
+      # If nil and the "default" network is set use the default us-central1-f.
       #
       # @return [String]
       attr_accessor :zone
@@ -317,6 +317,7 @@ module VagrantPlugins
           t = Time.now
           @name = "i-#{t.strftime("%Y%m%d%H")}-" + SecureRandom.hex(4)
         end
+
         # Network defaults to 'default'
         @network = "default" if @network == UNSET_VALUE
 
@@ -326,8 +327,13 @@ module VagrantPlugins
         # Subnetwork defaults to nil
         @subnetwork = nil if @subnetwork == UNSET_VALUE
 
-        # Default zone is us-central1-f.
-        @zone = "us-central1-f" if @zone == UNSET_VALUE
+        # Default zone is us-central1-f if using the default network
+        if @zone == UNSET_VALUE
+          @zone = nil
+          if @network == "default"
+            @zone = "us-central1-f"
+          end
+        end
 
         # autodelete_disk defaults to true
         @autodelete_disk = true if @autodelete_disk == UNSET_VALUE
@@ -422,10 +428,10 @@ module VagrantPlugins
             errors << I18n.t("vagrant_google.config.image_and_image_family_set") if \
              config.image
           end
-        end
 
-        errors << I18n.t("vagrant_google.config.image_required") if config.image.nil? && config.image_family.nil?
-        errors << I18n.t("vagrant_google.config.name_required") if @name.nil?
+          errors << I18n.t("vagrant_google.config.image_required") if config.image.nil? && config.image_family.nil?
+          errors << I18n.t("vagrant_google.config.name_required") if @name.nil?
+        end
 
         if @service_accounts
           machine.env.ui.warn(I18n.t("vagrant_google.config.service_accounts_deprecaated"))

--- a/test/unit/common/config_test.rb
+++ b/test/unit/common/config_test.rb
@@ -67,6 +67,13 @@ describe VagrantPlugins::Google::Config do
       end
     end
 
+    it "should raise error when network is not default and zone is not overriden" do
+      instance.network = "not-default"
+      instance.finalize!
+      errors = instance.validate("foo")["Google Provider"]
+      expect(errors).to include(/zone_required/)
+    end
+
     it "should raise error when preemptible and auto_restart is true" do
       instance.preemptible = true
       instance.auto_restart = true


### PR DESCRIPTION
Previously, if the zone was not set in a configuration then we were
always setting the zone to `us-central1-f` as a default. This zone is a
reasonable default when we expect that the `default` network is being
used. However, using this as the automatic default in the case that a
non-default network was set but not a zone throws an error that is
misleading.

This change adds some logic to test if the `default` network is being
used before setting the zone to the default. This should cause a more
useful error to surface when the network is set but the zone isn't.

Unit tests included.