### PR TITLE
fix: Better merging of config attributes containing collections

### DIFF
--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -278,6 +278,10 @@ module VagrantPlugins
           result.metadata.merge!(self.metadata)
           result.metadata.merge!(other.metadata)
 
+          # Merge in the labels
+          result.labels.merge!(self.labels)
+          result.labels.merge!(other.labels)
+
           # Merge in the tags
           result.tags |= self.tags
           result.tags |= other.tags

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -285,6 +285,10 @@ module VagrantPlugins
           # Merge in the tags
           result.tags |= self.tags
           result.tags |= other.tags
+
+          # Merge in the additional disks
+          result.additional_disks |= self.additional_disks
+          result.additional_disks |= other.additional_disks
         end
       end
 

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -277,6 +277,10 @@ module VagrantPlugins
           # Merge in the metadata
           result.metadata.merge!(self.metadata)
           result.metadata.merge!(other.metadata)
+
+          # Merge in the tags
+          result.tags |= self.tags
+          result.tags |= other.tags
         end
       end
 

--- a/test/unit/common/config_test.rb
+++ b/test/unit/common/config_test.rb
@@ -252,6 +252,17 @@ describe VagrantPlugins::Google::Config do
         })
       end
 
+      it "should merge the labels" do
+        first.labels["one"] = "one"
+        second.labels["two"] = "two"
+
+        third = first.merge(second)
+        expect(third.labels).to eq({
+          "one" => "one",
+          "two" => "two"
+        })
+      end
+
       it "should merge the tags" do
         first.tags = ["foo", "bar"]
         second.tags = ["biz"]

--- a/test/unit/common/config_test.rb
+++ b/test/unit/common/config_test.rb
@@ -251,6 +251,16 @@ describe VagrantPlugins::Google::Config do
           "two" => "bar"
         })
       end
+
+      it "should merge the tags" do
+        first.tags = ["foo", "bar"]
+        second.tags = ["biz"]
+
+        third = first.merge(second)
+        expect(third.tags).to include("foo")
+        expect(third.tags).to include("bar")
+        expect(third.tags).to include("biz")
+      end
     end
 
     describe "zone_preemptible" do

--- a/test/unit/common/config_test.rb
+++ b/test/unit/common/config_test.rb
@@ -272,6 +272,16 @@ describe VagrantPlugins::Google::Config do
         expect(third.tags).to include("bar")
         expect(third.tags).to include("biz")
       end
+
+      it "should merge the additional_disks" do
+        first.additional_disks = [{:one => "one"}]
+        second.additional_disks = [{:two => "two"}]
+
+        third = first.merge(second)
+        expect(third.additional_disks).to contain_exactly(
+          {:one => "one"}, {:two => "two"}
+        )
+      end
     end
 
     describe "zone_preemptible" do


### PR DESCRIPTION
Previously, only `metadata` was being merged if there were multiple configurations.

This change adds `labels`, `tags`, and `additional_disks` to the merging strategy. 