### PR TITLE
Add support for Windows hosts through WinRM

### DIFF
--- a/lib/vagrant-google/action.rb
+++ b/lib/vagrant-google/action.rb
@@ -82,6 +82,15 @@ module VagrantPlugins
         end
       end
 
+      # This action is called to setup the Windows user/password on the machine.
+      def self.action_setup_winrm_password
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConfigValidate
+          b.use ConnectGoogle
+          b.use SetupWinrmPassword
+        end
+      end
+
       # This action is called to read the state of the machine. The
       # resulting state is expected to be put into the `:machine_state_id`
       # key.
@@ -182,6 +191,7 @@ module VagrantPlugins
       autoload :MessageNotCreated, action_root.join("message_not_created")
       autoload :MessageWillNotDestroy, action_root.join("message_will_not_destroy")
       autoload :ReadSSHInfo, action_root.join("read_ssh_info")
+      autoload :SetupWinrmPassword, action_root.join('setup_winrm_password')
       autoload :ReadState, action_root.join("read_state")
       autoload :RunInstance, action_root.join("run_instance")
       autoload :StartInstance, action_root.join("start_instance")

--- a/lib/vagrant-google/action/setup_winrm_password.rb
+++ b/lib/vagrant-google/action/setup_winrm_password.rb
@@ -1,0 +1,72 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Changes:
+# April 2019: Modified example found here:
+# https://github.com/GoogleCloudPlatform/compute-image-windows/blob/master/examples/windows_auth_python_sample.py
+# to enable WinRM with vagrant.
+
+module VagrantPlugins
+  module Google
+    module Action
+      # Sets up a temporary WinRM password using Google's method for
+      # establishing a new password over encrypted channels.
+      class SetupWinrmPassword
+        def initialize(app, env)
+          @app    = app
+          @logger = Log4r::Logger.new("vagrant_google::action::setup_winrm_password")
+        end
+
+        def setup_password(env, instance, zone, user)
+          # Setup
+          compute = env[:google_compute]
+          server = compute.servers.get(instance, zone)
+          password = server.reset_windows_password(user)
+
+          env[:ui].info("Temp Password: #{password}")
+
+          password
+        end
+
+        def call(env)
+          # Get the configs
+          zone = env[:machine].provider_config.zone
+          zone_config = env[:machine].provider_config.get_zone_config(zone)
+
+          instance = zone_config.name
+          user = env[:machine].config.winrm.username
+          pass = env[:machine].config.winrm.password
+
+          # Get Temporary Password, set WinRM password
+          temp_pass = setup_password(env, instance, zone, user)
+          env[:machine].config.winrm.password = temp_pass
+
+          # Wait for WinRM To be Ready
+          env[:ui].info("Waiting for WinRM To be ready")
+          env[:machine].communicate.wait_for_ready(60)
+
+          # Use WinRM to Change Password to one in Vagrantfile
+          env[:ui].info("Changing password from temporary to winrm password")
+          winrmcomm = VagrantPlugins::CommunicatorWinRM::Communicator.new(env[:machine])
+          cmd = "net user #{user} #{pass}"
+          opts = { elevated: true }
+          winrmcomm.test(cmd, opts)
+
+          # Update WinRM password to reflect updated one
+          env[:machine].config.winrm.password = pass
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-google/action/start_instance.rb
+++ b/lib/vagrant-google/action/start_instance.rb
@@ -65,9 +65,9 @@ module VagrantPlugins
           @logger.info("Time to instance ready: #{env[:metrics]["instance_ready_time"]}")
 
           unless env[:interrupted]
-            env[:metrics]["instance_ssh_time"] = Util::Timer.time do
-              # Wait for SSH to be ready.
-              env[:ui].info(I18n.t("vagrant_google.waiting_for_ssh"))
+            env[:metrics]["instance_comm_time"] = Util::Timer.time do
+              # Wait for Comms to be ready.
+              env[:ui].info(I18n.t("vagrant_google.waiting_for_comm"))
               while true
                 # If we're interrupted then just back out
                 break if env[:interrupted]
@@ -76,7 +76,7 @@ module VagrantPlugins
               end
             end
 
-            @logger.info("Time for SSH ready: #{env[:metrics]["instance_ssh_time"]}")
+            @logger.info("Time for Comms ready: #{env[:metrics]["instance_comm_time"]}")
 
             # Ready and booted!
             env[:ui].info(I18n.t("vagrant_google.ready"))

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -178,6 +178,11 @@ module VagrantPlugins
       # @return [Array<Hash>]
       attr_accessor :additional_disks
 
+      # (Optional - Override default WinRM setup before for Public Windows images)
+      #
+      # @return [Boolean]
+      attr_accessor :setup_winrm_password
+
       def initialize(zone_specific=false)
         @google_json_key_location = UNSET_VALUE
         @google_project_id   = UNSET_VALUE
@@ -210,6 +215,7 @@ module VagrantPlugins
         @service_accounts    = UNSET_VALUE
         @service_account     = UNSET_VALUE
         @additional_disks    = []
+        @setup_winrm_password = UNSET_VALUE
 
         # Internal state (prefix with __ so they aren't automatically
         # merged)
@@ -381,6 +387,9 @@ module VagrantPlugins
 
         # Default IAM service account
         @service_account = nil if @service_account == UNSET_VALUE
+
+        # Default Setup WinRM Password
+        @setup_winrm_password = nil if @setup_winrm_password == UNSET_VALUE
 
         # Config option service_accounts is deprecated
         if @service_accounts

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -14,8 +14,8 @@ en:
       Instance is not created. Please run `vagrant up` first.
     ready: |-
       Machine is booted and ready for use!
-    ready_ssh: |-
-      Machine is ready for SSH access!
+    ready_comm: |-
+      Machine is ready for Communicator access!
     rsync_not_found_warning: |-
       Warning! Folder sync disabled because the rsync binary is missing.
       Make sure rsync is installed and the binary can be found in the PATH.
@@ -31,8 +31,8 @@ en:
       Waiting for GCP operation '%{name}' to finish...
     waiting_for_ready: |-
       Waiting for instance to become "ready"...
-    waiting_for_ssh: |-
-      Waiting for SSH to become available...
+    waiting_for_comm: |-
+      Waiting for Communicator to become available...
     warn_networks: |-
       Warning! The Google provider doesn't support any of the Vagrant
       high-level network configurations (`config.vm.network`). They

--- a/vagrant-google.gemspec
+++ b/vagrant-google.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-google"
 
-  s.add_runtime_dependency "fog-google", "~> 1.9.1"
+  s.add_runtime_dependency "fog-google", "~> 1.10.0"
 
   # This is a restriction to avoid errors on `failure_message_for_should`
   # TODO: revise after vagrant_spec goes past >0.0.1 (at master@e623a56)


### PR DESCRIPTION
Fixes #173.

Based on WinRM plugin from https://github.com/Azure/vagrant-azure
and existing code here.

Windows instances are already setup to use WinRM, however
setting up a temporary password is required before being
able to connect.  This feature uses the Google APIs directly
since the functionality to reset Windows passwords is not
available in fog-google.

Once a temporary password is set, the final password is pulled
from the Vagrantfile and set over the WinRM channel.