### PR TITLE
Deprecate google_client_email parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ vendor/*
 
 # Intellij projects folder
 .idea
+
+# Env
+setenv_*.sh

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider :google do |google, override|
     google.google_project_id = "YOUR_GOOGLE_CLOUD_PROJECT_ID"
-    google.google_client_email = "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"
     google.google_json_key_location = "/path/to/your/private-key.json"
     
     google.image_family = 'ubuntu-1604-lts'
@@ -165,8 +164,6 @@ configuration for this provider.
 
 This provider exposes quite a few provider-specific configuration options:
 
-* `google_client_email` - The Client Email address for your Service Account.  
-  (Can also be configured with `GOOGLE_CLIENT_EMAIL` environment variable.)
 * `google_json_key_location` - The location of the JSON private key file matching your
   Service Account.  
   (Can also be configured with `GOOGLE_JSON_KEY_LOCATION` environment variable.)
@@ -231,7 +228,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider :google do |google|
     google.google_project_id = "YOUR_GOOGLE_CLOUD_PROJECT_ID"
-    google.google_client_email = "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"
     google.google_json_key_location = "/path/to/your/private-key.json"
   end
 end
@@ -249,7 +245,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider :google do |google|
     google.google_project_id = "YOUR_GOOGLE_CLOUD_PROJECT_ID"
-    google.google_client_email = "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"
     google.google_json_key_location = "/path/to/your/private-key.json"
 
     # Make sure to set this to trigger the zone_config
@@ -320,7 +315,6 @@ Before you start acceptance tests, you'll need to set the authentication
 shell variables accordingly:
 
 ```sh
-export GOOGLE_CLIENT_EMAIL="your-google_service_account_email@developer.gserviceaccount.com"
 export GOOGLE_PROJECT_ID="your-google-cloud-project-id"
 export GOOGLE_JSON_KEY_LOCATION="/full/path/to/your/private-key.json"
 

--- a/lib/vagrant-google/action/connect_google.rb
+++ b/lib/vagrant-google/action/connect_google.rb
@@ -36,16 +36,8 @@ module VagrantPlugins
             :google_project      => provider_config.google_project_id,
           }
 
-          unless provider_config.google_client_email.nil?
-            fog_config[:google_client_email] = provider_config.google_client_email
-          end
-
           unless provider_config.google_json_key_location.nil?
             fog_config[:google_json_key_location] = find_key(provider_config.google_json_key_location, env)
-          end
-
-          if provider_config.google_client_email.nil? and provider_config.google_json_key_location.nil?
-            fog_config[:google_application_default] = true
           end
 
           @logger.info("Creating Google API client and adding to Vagrant environment")

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -17,11 +17,6 @@ require "securerandom"
 module VagrantPlugins
   module Google
     class Config < Vagrant.plugin("2", :config) # rubocop:disable Metrics/ClassLength
-      # The Service Account Client ID Email address
-      #
-      # @return [String]
-      attr_accessor :google_client_email
-
       # The path to the Service Account json-formatted private key
       #
       # @return [String]
@@ -179,7 +174,6 @@ module VagrantPlugins
       attr_accessor :additional_disks
 
       def initialize(zone_specific=false)
-        @google_client_email = UNSET_VALUE
         @google_json_key_location = UNSET_VALUE
         @google_project_id   = UNSET_VALUE
         @image               = UNSET_VALUE
@@ -295,7 +289,6 @@ module VagrantPlugins
       def finalize! # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         # Try to get access keys from standard Google environment variables; they
         # will default to nil if the environment variables are not present.
-        @google_client_email = ENV['GOOGLE_CLIENT_EMAIL'] if @google_client_email == UNSET_VALUE
         @google_json_key_location = ENV['GOOGLE_JSON_KEY_LOCATION'] if @google_json_key_location == UNSET_VALUE
         @google_project_id = ENV['GOOGLE_PROJECT_ID'] if @google_project_id == UNSET_VALUE
 

--- a/tasks/acceptance.rake
+++ b/tasks/acceptance.rake
@@ -66,7 +66,6 @@ namespace :acceptance do
       image_family
       synced_folder/rsync
       provisioner/shell
-      provisioner/chef-solo
     ).map{ |s| "provider/google/#{s}" }
 
     command = "vagrant-spec test --components=#{components.join(" ")}"

--- a/tasks/acceptance.rake
+++ b/tasks/acceptance.rake
@@ -37,10 +37,6 @@ namespace :acceptance do
       abort "Environment variable GOOGLE_PROJECT_ID is not set. Aborting."
     end
 
-    unless ENV["GOOGLE_CLIENT_EMAIL"]
-      abort "Environment variable GOOGLE_CLIENT_EMAIL is not set. Aborting."
-    end
-
     unless ENV["GOOGLE_SSH_USER"]
       yellow "WARNING: GOOGLE_SSH_USER variable is not set. Will try to start tests using insecure Vagrant private key."
     end

--- a/test/unit/common/config_test.rb
+++ b/test/unit/common/config_test.rb
@@ -99,13 +99,11 @@ describe VagrantPlugins::Google::Config do
         end
       end
 
-      its("google_client_email") { should be_nil }
       its("google_json_key_location") { should be_nil }
     end
 
     context "with Google credential environment variables" do
       before :each do
-        allow(ENV).to receive(:[]).with("GOOGLE_CLIENT_EMAIL").and_return("client_id_email")
         allow(ENV).to receive(:[]).with("GOOGLE_JSON_KEY_LOCATION").and_return("/path/to/json/key")
       end
 
@@ -115,7 +113,6 @@ describe VagrantPlugins::Google::Config do
         end
       end
 
-      its("google_client_email") { should == "client_id_email" }
       its("google_json_key_location") { should == "/path/to/json/key" }
     end
   end
@@ -297,7 +294,6 @@ describe VagrantPlugins::Google::Config do
 
       before :each do
         # Stub out required env to make sure we produce only errors we're looking for.
-        allow(ENV).to receive(:[]).with("GOOGLE_CLIENT_EMAIL").and_return("client_id_email")
         allow(ENV).to receive(:[]).with("GOOGLE_PROJECT_ID").and_return("my-awesome-project")
         allow(ENV).to receive(:[]).with("GOOGLE_JSON_KEY_LOCATION").and_return("/path/to/json/key")
         allow(ENV).to receive(:[]).with("GOOGLE_SSH_KEY_LOCATION").and_return("/path/to/ssh/key")

--- a/vagrantfile_examples/Vagrantfile.multiple_machines
+++ b/vagrantfile_examples/Vagrantfile.multiple_machines
@@ -24,7 +24,6 @@
 
 # Customize these global variables
 $GOOGLE_PROJECT_ID = "YOUR_GOOGLE_CLOUD_PROJECT_ID"
-$GOOGLE_CLIENT_EMAIL = "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"
 $GOOGLE_JSON_KEY_LOCATION = "/path/to/your/private-key.json"
 $LOCAL_USER = "mitchellh"
 $LOCAL_SSH_KEY = "~/.ssh/id_rsa"
@@ -54,7 +53,6 @@ Vagrant.configure("2") do |config|
   config.vm.define :z1c do |z1c|
     z1c.vm.provider :google do |google, override|
       google.google_project_id = $GOOGLE_PROJECT_ID
-      google.google_client_email = $GOOGLE_CLIENT_EMAIL
       google.google_json_key_location = $GOOGLE_JSON_KEY_LOCATION
       google.zone = "us-central1-c"
 
@@ -74,7 +72,6 @@ Vagrant.configure("2") do |config|
   config.vm.define :z1f do |z1f|
     z1f.vm.provider :google do |google, override|
       google.google_project_id = $GOOGLE_PROJECT_ID
-      google.google_client_email = $GOOGLE_CLIENT_EMAIL
       google.google_json_key_location = $GOOGLE_JSON_KEY_LOCATION
       google.zone = "us-central1-f"
 

--- a/vagrantfile_examples/Vagrantfile.provision_single
+++ b/vagrantfile_examples/Vagrantfile.provision_single
@@ -20,7 +20,6 @@
 
 # Customize these global variables
 $GOOGLE_PROJECT_ID = "YOUR_GOOGLE_CLOUD_PROJECT_ID"
-$GOOGLE_CLIENT_EMAIL = "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"
 $GOOGLE_JSON_KEY_LOCATION = "/path/to/your/private-key.json"
 $LOCAL_USER = "mitchellh"
 $LOCAL_SSH_KEY = "~/.ssh/id_rsa"
@@ -31,7 +30,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider :google do |google, override|
     google.google_project_id = $GOOGLE_PROJECT_ID
-    google.google_client_email = $GOOGLE_CLIENT_EMAIL
     google.google_json_key_location = $GOOGLE_JSON_KEY_LOCATION
 
     # Override provider defaults

--- a/vagrantfile_examples/Vagrantfile.simple
+++ b/vagrantfile_examples/Vagrantfile.simple
@@ -19,7 +19,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider :google do |google, override|
     google.google_project_id = "YOUR_GOOGLE_CLOUD_PROJECT_ID"
-    google.google_client_email = "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"
     google.google_json_key_location = "/path/to/your/private-key.json"
 
     google.image_family = 'ubuntu-1604-lts'

--- a/vagrantfile_examples/Vagrantfile.zone_config
+++ b/vagrantfile_examples/Vagrantfile.zone_config
@@ -19,7 +19,6 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider :google do |google, override|
     google.google_project_id = "YOUR_GOOGLE_CLOUD_PROJECT_ID"
-    google.google_client_email = "YOUR_SERVICE_ACCOUNT_EMAIL_ADDRESS"
     google.google_json_key_location = "/path/to/your/private-key.json"
 
     override.ssh.username = "mitchellh"


### PR DESCRIPTION
No longer needed since https://github.com/fog/fog-google/commit/03e91b1b1526e672eb36816aafda022b6da4b135

Fixing #219 