### PR TITLE
Locked the vagrant dep to 2.2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,9 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem 'vagrant', git: "https://github.com/hashicorp/vagrant.git"
+
+  # TODO(temikus): remove to 2.2.4 tag lock when
+  # https://github.com/hashicorp/vagrant/pull/10945 is resolved
+  gem 'vagrant', git: "https://github.com/hashicorp/vagrant.git", :tag => 'v2.2.4'
   gem 'vagrant-spec', git: "https://github.com/hashicorp/vagrant-spec.git"
 end


### PR DESCRIPTION
Due to bundler breakage in 2.2.5, see https://github.com/hashicorp/vagrant/pull/10945 for more info