### PR TITLE
Fix additional disks being auto-deleted unless a disk type is specified.

### DIFF
--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -201,7 +201,7 @@ module VagrantPlugins
 
               # Get additional disk auto delete
               additional_disk_auto_delete = nil
-              if disk_config[:disk_type].nil?
+              if disk_config[:autodelete_disk].nil?
                 # Default auto delete to true
                 additional_disk_auto_delete = true
               else


### PR DESCRIPTION
It looks like a simple typo causes additional disks to always be auto-deleted unless a disk type is set, which lead to great confusion until I took a look at the code :laughing:.

Thanks for providing this awesome plugin by the way. It's very useful.