### PR TITLE
chore: Update Gemfile with new `vagrant-spec` branch name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,5 +25,5 @@ group :development do
   # Vagrant environment itself using `vagrant plugin`.
 
   gem 'vagrant', git: "https://github.com/hashicorp/vagrant.git"
-  gem 'vagrant-spec', git: "https://github.com/hashicorp/vagrant-spec.git"
+  gem 'vagrant-spec', git: "https://github.com/hashicorp/vagrant-spec.git", branch: "main"
 end


### PR DESCRIPTION
Hashicorp changed the default branch in `vagrant-spec`.

hashicorp/vagrant-spec#41