### PR TITLE
Fix shielded api

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,12 @@ Style/StringLiterals:
 
 Style/IfUnlessModifier:
   Enabled: false
+
+Metrics/LineLength:
+  Max: 120
+
+Layout/HashAlignment:
+  EnforcedHashRocketStyle: table
+
+Style/HashSyntax:
+  EnforcedStyle: no_mixed_keys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Next
+
+
 ## 2.5.0 (September 2019)
 
 ### User-facing

--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -267,26 +267,33 @@ module VagrantPlugins
             end
 
             defaults = {
-              :name                     => name,
-              :zone                     => zone,
-              :machine_type             => machine_type,
-              :disk_size                => disk_size,
-              :disk_type                => disk_type,
-              :image                    => image,
-              :network_interfaces       => network_interfaces,
-              :metadata                 => { :items => metadata.each.map { |k, v| {:key => k.to_s, :value => v.to_s} } },
-              :labels                   => labels,
-              :tags                     => { :items => tags },
-              :can_ip_forward           => can_ip_forward,
-              :use_private_ip           => use_private_ip,
-              :external_ip              => external_ip,
-              :network_ip               => network_ip,
-              :disks                    => disks,
-              :scheduling               => scheduling,
-              :service_accounts         => service_accounts,
-              :guest_accelerators       => accelerators_url,
-              :shielded_instance_config => shielded_instance_config,
+              :name               => name,
+              :zone               => zone,
+              :machine_type       => machine_type,
+              :disk_size          => disk_size,
+              :disk_type          => disk_type,
+              :image              => image,
+              :network_interfaces => network_interfaces,
+              :metadata           => { :items => metadata.each.map { |k, v| { :key => k.to_s, :value => v.to_s } } },
+              :labels             => labels,
+              :tags               => { :items => tags },
+              :can_ip_forward     => can_ip_forward,
+              :use_private_ip     => use_private_ip,
+              :external_ip        => external_ip,
+              :network_ip         => network_ip,
+              :disks              => disks,
+              :scheduling         => scheduling,
+              :service_accounts   => service_accounts,
+              :guest_accelerators => accelerators_url
             }
+
+            # XXX HACK - only add  of the parameters are set in :shielded_instance_config we need to drop the field from
+            # the API call otherwise we'll error out with Google::Apis::ClientError
+            # TODO(temikus): Remove if the API changes, see internal GOOG ref: b/175063371
+            if shielded_instance_config.has_value?(true)
+              defaults[:shielded_instance_config] = shielded_instance_config
+            end
+
             server = env[:google_compute].servers.create(defaults)
             @logger.info("Machine '#{zone}:#{name}' created.")
           rescue *FOG_ERRORS => e

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -419,13 +419,13 @@ module VagrantPlugins
         end
 
         # enable_secure_boot defaults to nil
-        @enable_secure_boot = nil if @enable_secure_boot == UNSET_VALUE
+        @enable_secure_boot = false if @enable_secure_boot == UNSET_VALUE
 
         # enable_vtpm defaults to nil
-        @enable_vtpm = nil if @enable_vtpm == UNSET_VALUE
+        @enable_vtpm = false if @enable_vtpm == UNSET_VALUE
 
         # enable_integrity_monitoring defaults to nil
-        @enable_integrity_monitoring = nil if @enable_integrity_monitoring == UNSET_VALUE
+        @enable_integrity_monitoring = false if @enable_integrity_monitoring == UNSET_VALUE
 
         # Compile our zone specific configurations only within
         # NON-zone-SPECIFIC configurations.

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -1,0 +1,37 @@
+require "fileutils"
+
+# Helper method to insert text after a line that matches the regex
+def insert_after_line(file, insert, regex = /^## Next/)
+  tempfile = File.open("#{file}.tmp", "w")
+  f = File.new(file)
+  f.each do |line|
+    tempfile << line
+    next unless line =~ regex
+
+    tempfile << "\n"
+    tempfile << insert
+    tempfile << "\n"
+  end
+  f.close
+  tempfile.close
+
+  FileUtils.mv("#{file}.tmp", file)
+end
+
+# Extracts all changes that have been made after the latest pushed tag
+def changes_since_last_tag
+  `git --no-pager log $(git describe --tags --abbrev=0)..HEAD --grep="Merge" --pretty=format:"%t - %s%n%b%n"`
+end
+
+# Extracts all github users contributed since last tag
+def users_since_last_tag
+  `git --no-pager log $(git describe --tags --abbrev=0)..HEAD --grep="Merge" --pretty=format:"%s" | cut -d' ' -f 6 | cut -d/ -f1 | uniq`
+end
+
+namespace :changelog do
+  task :generate do
+    insert_after_line("CHANGELOG.md", changes_since_last_tag, /^## Next/)
+    printf("Users contributed since last release:\n")
+    printf(users_since_last_tag)
+  end
+end

--- a/test/unit/common/config_test.rb
+++ b/test/unit/common/config_test.rb
@@ -51,9 +51,9 @@ describe VagrantPlugins::Google::Config do
     its("auto_restart")                { should }
     its("on_host_maintenance")         { should == "MIGRATE" }
     its("accelerators")                { should == [] }
-    its("enable_secure_boot")          { should be_nil }
-    its("enable_vtpm")                 { should be_nil }
-    its("enable_integrity_monitoring") { should be_nil }
+    its("enable_secure_boot")          { should be_falsey }
+    its("enable_vtpm")                 { should be_falsey }
+    its("enable_integrity_monitoring") { should be_falsey }
   end
 
   describe "overriding defaults" do


### PR DESCRIPTION
There was a small issue introduced in #248 that I didn't notice, which resulted in following errors running any non-shielded VM image:

```
stderr: /Users/temikus/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/google-api-client-0.50.0/lib/google/apis/core/http_command.rb:228:in `check_status': invalid: Invalid value for field 'resource.shieldedInstanceConfig': '{  "enableSecureBoot": false,  "enableVtpm": false,  "enableIntegrityMonitoring": false}'. Shielded VM Config can only be set when using a UEFI-compatible disk. (Google::Apis::ClientError)
```

Seems like the API just looks at the presence of the container and doesn't actually look into any of its' fields ¯\_(ツ)_/¯