### PR TITLE
Use google_application_default credentials by default

### DIFF
--- a/lib/vagrant-google/action/connect_google.rb
+++ b/lib/vagrant-google/action/connect_google.rb
@@ -38,6 +38,8 @@ module VagrantPlugins
 
           unless provider_config.google_json_key_location.nil?
             fog_config[:google_json_key_location] = find_key(provider_config.google_json_key_location, env)
+          else
+            fog_config[:google_application_default] = true
           end
 
           @logger.info("Creating Google API client and adding to Vagrant environment")


### PR DESCRIPTION
The current configuration works without specifying `google_json_key_location` but the output is full of `[fog][WARNING] Didn't detect any client auth settings, trying to fall back to application default credentials...` messages as that is the way `fog` works if its not set explicitly to use the default creds and because we go through that code-path many times.

Given this is the default behavior anyway, I suggest we fallback to using `google_application_default` by setting it to true explicitly.

As an alternative, I can make `google_application_default` use `find_key(provider_config.google_application_default, env)` and let the user default it to `true` while letting users explicitly set it to `false`.