### PR TITLE
Adds enable_display option

### DIFF
--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -72,6 +72,7 @@ module VagrantPlugins
           additional_disks            = zone_config.additional_disks
           accelerators                = zone_config.accelerators
           enable_secure_boot          = zone_config.enable_secure_boot
+          enable_display              = zone_config.enable_display
           enable_vtpm                 = zone_config.enable_vtpm
           enable_integrity_monitoring = zone_config.enable_integrity_monitoring
 
@@ -107,6 +108,7 @@ module VagrantPlugins
           env[:ui].info(" -- Additional Disks:     #{additional_disks}")
           env[:ui].info(" -- Accelerators:         #{accelerators}")
           env[:ui].info(" -- Secure Boot:          #{enable_secure_boot}") if enable_secure_boot
+          env[:ui].info(" -- Display Device:       #{enable_display}") if enable_display
           env[:ui].info(" -- vTPM:                 #{enable_vtpm}") if enable_vtpm
           env[:ui].info(" -- Integrity Monitoring: #{enable_integrity_monitoring}") if enable_integrity_monitoring
 
@@ -152,6 +154,9 @@ module VagrantPlugins
 
           # Munge shieldedInstance config
           shielded_instance_config = { :enable_secure_boot => enable_secure_boot, :enable_vtpm => enable_vtpm, :enable_integrity_monitoring => enable_integrity_monitoring }
+
+          # Munge displayDevice config
+          display_device = { :enable_display => enable_display }
 
           begin
             request_start_time = Time.now.to_i
@@ -292,6 +297,10 @@ module VagrantPlugins
             # TODO(temikus): Remove if the API changes, see internal GOOG ref: b/175063371
             if shielded_instance_config.has_value?(true)
               defaults[:shielded_instance_config] = shielded_instance_config
+            end
+
+            if display_device.has_value?(true)
+              defaults[:display_device] = display_device
             end
 
             server = env[:google_compute].servers.create(defaults)

--- a/lib/vagrant-google/config.rb
+++ b/lib/vagrant-google/config.rb
@@ -193,6 +193,11 @@ module VagrantPlugins
       # @return Boolean
       attr_accessor :enable_secure_boot
 
+      # whether the instance has a display enabled
+      #
+      # @return Boolean
+      attr_accessor :enable_display
+
       # whether the instance has the vTPM enabled
       #
       # @return Boolean
@@ -238,6 +243,7 @@ module VagrantPlugins
         @setup_winrm_password        = UNSET_VALUE
         @accelerators                = []
         @enable_secure_boot          = UNSET_VALUE
+        @enable_display              = UNSET_VALUE
         @enable_vtpm                 = UNSET_VALUE
         @enable_integrity_monitoring = UNSET_VALUE
 
@@ -420,6 +426,9 @@ module VagrantPlugins
 
         # enable_secure_boot defaults to nil
         @enable_secure_boot = false if @enable_secure_boot == UNSET_VALUE
+
+        # enable_display defaults to nil
+        @enable_display = false if @enable_display == UNSET_VALUE
 
         # enable_vtpm defaults to nil
         @enable_vtpm = false if @enable_vtpm == UNSET_VALUE

--- a/vagrant-google.gemspec
+++ b/vagrant-google.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-google"
 
-  s.add_runtime_dependency "fog-google", "~> 1.12.0"
+  s.add_runtime_dependency "fog-google", "~> 1.17.0"
 
   # This is a restriction to avoid errors on `failure_message_for_should`
   # TODO: revise after vagrant_spec goes past >0.0.1 (at master@e623a56)


### PR DESCRIPTION
Adds ability to add a display device to the VM at creation time.

NOTE: Requires pending upstream change in fog-google (https://github.com/fog/fog-google/pull/550)