### PR TITLE
bump fog-google from 1.17.0 to 1.24.0

### DIFF
--- a/vagrant-google.gemspec
+++ b/vagrant-google.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-google"
 
-  s.add_runtime_dependency "fog-google", "~> 1.17.0"
+  s.add_runtime_dependency "fog-google", "~> 1.24.0"
 
   # This is a restriction to avoid errors on `failure_message_for_should`
   # TODO: revise after vagrant_spec goes past >0.0.1 (at master@e623a56)


### PR DESCRIPTION
for:
* https://github.com/mitchellh/vagrant-google/issues/271

I was getting a dependency error, 1.24.0 includes:
* https://github.com/fog/fog-google/pull/619

Which the [changelog](https://github.com/fog/fog-google/blob/master/CHANGELOG.md) says:
>  #619 Updated google-cloud-env requirement from ~> 1.2 to >= 1.2, < 3.0 [dependabot]