### PR TITLE
Update dependencied and required code to allow running it on new Vagrant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Ruby 2.6
+    - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.4
+        ruby-version: '3.4'
 
     - name: Unit tests
       run: |

--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -24,8 +24,8 @@ module VagrantPlugins
         include Vagrant::Util::Retryable
 
         FOG_ERRORS = [
-          Fog::Compute::Google::NotFound,
-          Fog::Compute::Google::Error,
+          Fog::Google::Compute::NotFound,
+          Fog::Google::Compute::Error,
           Fog::Errors::Error
         ].freeze
 

--- a/lib/vagrant-google/action/run_instance.rb
+++ b/lib/vagrant-google/action/run_instance.rb
@@ -193,10 +193,11 @@ module VagrantPlugins
                 source_image: image
               )
               disk.wait_for { disk.ready? }
+              disk.reload
               disk_created_by_vagrant = true
             else
               disk = env[:google_compute].disks.get(disk_name, zone)
-              if disk.nil?
+              if disk.nil? || disk.status.nil?
                 # disk not found... create it with name
                 disk = env[:google_compute].disks.create(
                   name: disk_name,
@@ -206,6 +207,7 @@ module VagrantPlugins
                   source_image: image
                 )
                 disk.wait_for { disk.ready? }
+                disk.reload
                 disk_created_by_vagrant = true
               end
             end
@@ -265,12 +267,14 @@ module VagrantPlugins
                   zone_name: zone,
                   source_image: additional_disk_image
                 )
+                additional_disk.wait_for { additional_disk.ready? }
+                additional_disk.reload
               else
                 # additional_disk_name set in disk_config
                 additional_disk_name = disk_config[:disk_name]
 
                 additional_disk = env[:google_compute].disks.get(additional_disk_name, zone)
-                if additional_disk.nil?
+                if additional_disk.nil? || additional_disk.status.nil?
                   # disk not found... create it with name
                   additional_disk = env[:google_compute].disks.create(
                     name: additional_disk_name,
@@ -280,6 +284,10 @@ module VagrantPlugins
                     source_image: additional_disk_image
                   )
                   additional_disk.wait_for { additional_disk.ready? }
+                  additional_disk.reload
+                else
+                  # disk exists, manually set self_link if not present
+                  additional_disk.self_link ||= "https://compute.googleapis.com/compute/v1/projects/#{project_id}/zones/#{zone}/disks/#{additional_disk_name}"
                 end
               end
 

--- a/lib/vagrant-google/action/start_instance.rb
+++ b/lib/vagrant-google/action/start_instance.rb
@@ -58,7 +58,7 @@ module VagrantPlugins
                       timeout: env[:machine].provider_config.instance_ready_timeout
               end
             end
-          rescue Fog::Compute::Google::Error => e
+          rescue Fog::Google::Compute::Error => e
             raise Errors::FogError, :message => e.message
           end
 

--- a/lib/vagrant-google/version.rb
+++ b/lib/vagrant-google/version.rb
@@ -13,6 +13,6 @@
 # limitations under the License.
 module VagrantPlugins
   module Google
-    VERSION = "2.7.0".freeze
+    VERSION = "2.8.0".freeze
   end
 end

--- a/test/unit/common/config_test.rb
+++ b/test/unit/common/config_test.rb
@@ -54,6 +54,7 @@ describe VagrantPlugins::Google::Config do
     its("enable_secure_boot")          { should be_falsey }
     its("enable_vtpm")                 { should be_falsey }
     its("enable_integrity_monitoring") { should be_falsey }
+    its("resource_policies")           { should == [] }
   end
 
   describe "overriding defaults" do

--- a/vagrant-google.gemspec
+++ b/vagrant-google.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-google"
 
-  s.add_runtime_dependency "fog-google", "~> 1.17.0"
+  s.add_runtime_dependency "fog-google", "~> 1.25.0"
 
   # This is a restriction to avoid errors on `failure_message_for_should`
   # TODO: revise after vagrant_spec goes past >0.0.1 (at master@e623a56)


### PR DESCRIPTION
This pull request updates the project to support newer dependencies, modernizes the Ruby version, and introduces a minor feature improvement. The most significant changes are upgrading the `fog-google` dependency, updating the supported Ruby version, and adding a new default for `resource_policies` in configuration tests.

Dependency and compatibility updates:

* Upgraded the `fog-google` gem dependency to version `~> 1.25.0` in `vagrant-google.gemspec` to ensure compatibility with newer versions.
* Updated the Ruby version used in CI and development from `2.7.4` to `3.4`, and removed the specific Ruby version label in `.github/workflows/ci.yml`.

Code and API adjustments for updated dependencies:

* Updated references to Fog error classes from `Fog::Compute::Google::*` to `Fog::Google::Compute::*` in `lib/vagrant-google/action/run_instance.rb` and `lib/vagrant-google/action/start_instance.rb` to match the new `fog-google` gem API. [[1]](diffhunk://#diff-cc88f403effa205e415ea384a156a403d90549296b462aa9e228a6d653a0305fL27-R28) [[2]](diffhunk://#diff-2d3534552193be80efa13fa63adc81b7d073198419a7488ea1c74b4d430a1cc8L61-R61)

Feature and test improvements:

* Added a test to verify that the default value for `resource_policies` is an empty array in `test/unit/common/config_test.rb`.

Versioning:

* Bumped the plugin version from `2.7.0` to `2.8.0` in `lib/vagrant-google/version.rb`.